### PR TITLE
Transparently match HEAD routes in a spec-compliant manner

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,21 @@ $dispatcher = FastRoute\simpleDispatcher(function(FastRoute\RouteCollector $r) {
 The above options array corresponds to the defaults. By replacing `GroupCountBased` by
 `GroupPosBased` you could switch to a different dispatching strategy.
 
+#### A Note on HEAD Requests
+
+The HTTP spec requires servers to [support both GET and HEAD methods][2616-511]:
+
+> The methods GET and HEAD MUST be supported by all general-purpose servers
+
+To avoid forcing users to manually register HEAD routes for each resource we fallback to matching an
+available GET route for a given resource. The PHP web SAPI transparently removes the entity body
+from HEAD responses so this behavior has no effect on the vast majority of users.
+
+However, implementors using FastRoute outside the web SAPI environment (e.g. a custom server) MUST
+NOT send entity bodies generated in response to HEAD requests. If you are a non-SAPI user this is
+*your responsibility*; FastRoute has no purview to prevent you from breaking HTTP in such cases.
+
+Finally, note that applications MAY always specify their own HEAD method route for a given
+resource to bypass this behavior entirely.
+
+[2616-511]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.1 "RFC 2616 Section 5.1.1"

--- a/src/Dispatcher/GroupCountBased.php
+++ b/src/Dispatcher/GroupCountBased.php
@@ -23,11 +23,14 @@ class GroupCountBased implements Dispatcher {
 
     private function dispatchStaticRoute($httpMethod, $uri) {
         $routes = $this->staticRoutes[$uri];
-        if (!isset($routes[$httpMethod])) {
+
+        if (isset($routes[$httpMethod])) {
+            return [self::FOUND, $routes[$httpMethod], []];
+        } elseif ($httpMethod === 'HEAD' && isset($routes['GET'])) {
+            return [self::FOUND, $routes['GET'], []];
+        } else {
             return [self::METHOD_NOT_ALLOWED, array_keys($routes)];
         }
-
-        return [self::FOUND, $routes[$httpMethod], []];
     }
 
     private function dispatchVariableRoute($httpMethod, $uri) {
@@ -38,7 +41,11 @@ class GroupCountBased implements Dispatcher {
 
             $routes = $this->variableRoutes[$i][count($matches)];
             if (!isset($routes[$httpMethod])) {
-                return [self::METHOD_NOT_ALLOWED, array_keys($routes)];
+                if ($httpMethod === 'HEAD' && isset($routes['GET'])) {
+                    $httpMethod = 'GET';
+                } else {
+                    return [self::METHOD_NOT_ALLOWED, array_keys($routes)];
+                }
             }
 
             list($handler, $varNames) = $routes[$httpMethod];

--- a/src/Dispatcher/GroupPosBased.php
+++ b/src/Dispatcher/GroupPosBased.php
@@ -23,11 +23,14 @@ class GroupPosBased implements Dispatcher {
 
     private function dispatchStaticRoute($httpMethod, $uri) {
         $routes = $this->staticRoutes[$uri];
-        if (!isset($routes[$httpMethod])) {
+
+        if (isset($routes[$httpMethod])) {
+            return [self::FOUND, $routes[$httpMethod], []];
+        } elseif ($httpMethod === 'HEAD' && isset($routes['GET'])) {
+            return [self::FOUND, $routes['GET'], []];
+        } else {
             return [self::METHOD_NOT_ALLOWED, array_keys($routes)];
         }
-
-        return [self::FOUND, $routes[$httpMethod], []];
     }
 
     private function dispatchVariableRoute($httpMethod, $uri) {
@@ -41,7 +44,11 @@ class GroupPosBased implements Dispatcher {
 
             $routes = $this->variableRoutes[$i][$j];
             if (!isset($routes[$httpMethod])) {
-                return [self::METHOD_NOT_ALLOWED, array_keys($routes)];
+                if ($httpMethod === 'HEAD' && isset($routes['GET'])) {
+                    $httpMethod = 'GET';
+                } else {
+                    return [self::METHOD_NOT_ALLOWED, array_keys($routes)];
+                }
             }
 
             list($handler, $varNames) = $routes[$httpMethod];

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -142,20 +142,63 @@ abstract class DispatcherTest extends \PHPUnit_Framework_TestCase {
         $argDict = ['name' => 'rdlowrey', 'id' => '12345'];
 
         $cases[] = [$method, $uri, $callback, $handler, $argDict];
-        
+
         // 6 -------------------------------------------------------------------------------------->
 
         $callback = function(RouteCollector $r) {
             $r->addRoute('GET', '/user/{id:[0-9]+}', 'handler0');
             $r->addRoute('GET', '/user/12345/extension', 'handler1');
             $r->addRoute('GET', '/user/{id:[0-9]+}.{extension}', 'handler2');
-            
+
         };
 
-        $method = 'GET';
-        $uri = '/user/12345.svg';
+        // 7 ----- Test GET method fallback on HEAD route miss ------------------------------------>
+
+        $callback = function(RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler1');
+            $r->addRoute('GET', '/static0', 'handler2');
+            $r->addRoute('GET', '/static1', 'handler3');
+            $r->addRoute('HEAD', '/static1', 'handler4');
+        };
+
+        $method = 'HEAD';
+        $uri = '/user/rdlowrey';
+        $handler = 'handler0';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 8 ----- Test GET method fallback on HEAD route miss ------------------------------------>
+
+        // reuse $callback from #7
+
+        $method = 'HEAD';
+        $uri = '/user/rdlowrey/1234';
+        $handler = 'handler1';
+        $argDict = ['name' => 'rdlowrey', 'id' => '1234'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 9 ----- Test GET method fallback on HEAD route miss ------------------------------------>
+
+        // reuse $callback from #8
+
+        $method = 'HEAD';
+        $uri = '/static0';
         $handler = 'handler2';
-        $argDict = ['id' => '12345', 'extension' => 'svg'];
+        $argDict = [];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 10 ---- Test existing HEAD route used if available (no fallback) ----------------------->
+
+        // reuse $callback from #9
+
+        $method = 'HEAD';
+        $uri = '/static1';
+        $handler = 'handler4';
+        $argDict = [];
 
         $cases[] = [$method, $uri, $callback, $handler, $argDict];
 


### PR DESCRIPTION
As much as I dislike nested control structures I used them to determine if a HEAD method could be successfully mapped to a GET route ... Feel free to refactor it if you'd rather split the functionality into a separate method :)
