### PR TITLE
Add the convenience to create the same route for two or more http methods

### DIFF
--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -22,13 +22,18 @@ class RouteCollector {
      *
      * The syntax used in the $route string depends on the used route parser.
      *
-     * @param string $httpMethod
+     * @param mixed $httpMethod
      * @param string $route
      * @param mixed  $handler
      */
     public function addRoute($httpMethod, $route, $handler) {
         $routeData = $this->routeParser->parse($route);
-        $this->dataGenerator->addRoute($httpMethod, $routeData, $handler);
+        if (!is_array($httpMethod)) {
+            $httpMethod = array($httpMethod);
+        }
+        foreach ($httpMethod as $method) {
+            $this->dataGenerator->addRoute($method, $routeData, $handler);
+        }
     }
 
     /**

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -22,16 +22,13 @@ class RouteCollector {
      *
      * The syntax used in the $route string depends on the used route parser.
      *
-     * @param mixed $httpMethod
+     * @param string|string[] $httpMethod
      * @param string $route
      * @param mixed  $handler
      */
     public function addRoute($httpMethod, $route, $handler) {
         $routeData = $this->routeParser->parse($route);
-        if (!is_array($httpMethod)) {
-            $httpMethod = array($httpMethod);
-        }
-        foreach ($httpMethod as $method) {
+        foreach ((array) $httpMethod as $method) {
             $this->dataGenerator->addRoute($method, $routeData, $handler);
         }
     }


### PR DESCRIPTION
Add the convenience to create the same route for two or more http methods

For example:

You can add a route passing a string
```php
$r->addRoute('POST', '/xml/{name}', 'xml');
$r->addRoute('GET', '/xml/{name}', 'xml');
```

Or passing an array of methods (the result in this case will be the same):
```
$r->addRoute(array('GET', 'POST'), '/xml/{name}', 'xml');
```

Note: You can continue to pass the strings "POST", "GET", "DELETE" and "PUT". 
