### PR TITLE
Generic method matching and convenience methods for adding routes.

### DIFF
--- a/src/Dispatcher/RegexBasedAbstract.php
+++ b/src/Dispatcher/RegexBasedAbstract.php
@@ -53,10 +53,6 @@ abstract class RegexBasedAbstract implements Dispatcher {
     {
         $allowedMethods = [];
         foreach ($varRouteData as $method => $routeData) {
-            if ($method === $httpMethod) {
-                continue;
-            }
-
             $result = $this->dispatchVariableRoute($routeData, $uri);
             if ($result[0] === self::FOUND) {
                 $allowedMethods[] = $method;

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -34,6 +34,79 @@ class RouteCollector {
     }
 
     /**
+     * Adds a GET route to the collection.
+     *
+     * The syntax used in the $route string depends on the used route parser.
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function get($route, $handler) {
+        $this->addRoute('GET', $route, $handler);
+    }
+
+    /**
+     * Adds a POST route to the collection.
+     *
+     * The syntax used in the $route string depends on the used route parser.
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function post($route, $handler) {
+        $this->addRoute('POST', $route, $handler);
+    }
+
+    /**
+     * Adds a PUT route to the collection.
+     *
+     * The syntax used in the $route string depends on the used route parser.
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function put($route, $handler) {
+        $this->addRoute('PUT', $route, $handler);
+    }
+
+    /**
+     * Adds a DELETE route to the collection.
+     *
+     * The syntax used in the $route string depends on the used route parser.
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function delete($route, $handler) {
+        $this->addRoute('DELETE', $route, $handler);
+    }
+
+    /**
+     * Adds a HEAD route to the collection.
+     *
+     * The syntax used in the $route string depends on the used route parser.
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function head($route, $handler) {
+        $this->addRoute('HEAD', $route, $handler);
+    }
+
+    /**
+     * Adds an ANY route to the collection.  This route matches all HTTP methods.
+     *
+     * The syntax used in the $route string depends on the used route parser.
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function any($route, $handler) {
+        $this->addRoute('ANY', $route, $handler);
+    }
+
+
+    /**
      * Returns the collected route data, as provided by the data generator.
      *
      * @return array


### PR DESCRIPTION
So this one is a two-fer: a new method, ANY, that lets a user match any HTTP method for a given route, and convenience methods in RouteCollection like ->get, ->post, etc, to avoid the monotony of specifying the string, saving some keystrokes in the process.

I think #1 is important because, in my use case, and I'm sure others, I don't actually care about restricting specific methods on certain routes, and I think it's a bit of a kludge to have to do something like `['GET','POST','PUT', <other methods here>]`.  It would work, but it's still a whitelist that can change when what I really want to is to say "match this route, don't bother worrying about the method".

#2 is literally just there for convenience.  It makes the code for adding routes tidier and involves less keystrokes.