### PR TITLE
FIX: Check if simpleDispatcher() / cachedDispatcher() are already defined.

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -2,63 +2,70 @@
 
 namespace FastRoute;
 
-/**
- * @param callable $routeDefinitionCallback
- * @param array $options
- *
- * @return Dispatcher
- */
-function simpleDispatcher(callable $routeDefinitionCallback, array $options = []) {
-    $options += [
-        'routeParser' => 'FastRoute\\RouteParser\\Std',
-        'dataGenerator' => 'FastRoute\\DataGenerator\\GroupCountBased',
-        'dispatcher' => 'FastRoute\\Dispatcher\\GroupCountBased',
-    ];
+if ( ! function_exists('\FastRoute\simpleDispatcher') ) {
+    /**
+     * @param callable $routeDefinitionCallback
+     * @param array    $options
+     *
+     * @return Dispatcher
+     */
+    function simpleDispatcher( callable $routeDefinitionCallback, array $options = [ ] )
+    {
+        $options += [
+            'routeParser'   => 'FastRoute\\RouteParser\\Std',
+            'dataGenerator' => 'FastRoute\\DataGenerator\\GroupCountBased',
+            'dispatcher'    => 'FastRoute\\Dispatcher\\GroupCountBased',
+        ];
 
-    $routeCollector = new RouteCollector(
-        new $options['routeParser'], new $options['dataGenerator']
-    );
-    $routeDefinitionCallback($routeCollector);
+        $routeCollector = new RouteCollector(
+            new $options[ 'routeParser' ], new $options[ 'dataGenerator' ]
+        );
+        $routeDefinitionCallback( $routeCollector );
 
-    return new $options['dispatcher']($routeCollector->getData());
+        return new $options[ 'dispatcher' ]( $routeCollector->getData() );
+    }
 }
 
-/**
- * @param callable $routeDefinitionCallback
- * @param array $options
- *
- * @return Dispatcher
- */
-function cachedDispatcher(callable $routeDefinitionCallback, array $options = []) {
-    $options += [
-        'routeParser' => 'FastRoute\\RouteParser\\Std',
-        'dataGenerator' => 'FastRoute\\DataGenerator\\GroupCountBased',
-        'dispatcher' => 'FastRoute\\Dispatcher\\GroupCountBased',
-        'cacheDisabled' => false,
-    ];
+if ( ! function_exists('\FastRoute\cachedDispatcher') ) {
+    /**
+     * @param callable $routeDefinitionCallback
+     * @param array    $options
+     *
+     * @return Dispatcher
+     */
+    function cachedDispatcher( callable $routeDefinitionCallback, array $options = [ ] )
+    {
+        $options += [
+            'routeParser'   => 'FastRoute\\RouteParser\\Std',
+            'dataGenerator' => 'FastRoute\\DataGenerator\\GroupCountBased',
+            'dispatcher'    => 'FastRoute\\Dispatcher\\GroupCountBased',
+            'cacheDisabled' => false,
+        ];
 
-    if (!isset($options['cacheFile'])) {
-        throw new \LogicException('Must specify "cacheFile" option');
-    }
-
-    if (!$options['cacheDisabled'] && file_exists($options['cacheFile'])) {
-        $dispatchData = require $options['cacheFile'];
-        if (!is_array($dispatchData)) {
-            throw new \RuntimeException('Invalid cache file "' . $options['cacheFile'] . '"');
+        if (!isset( $options[ 'cacheFile' ] )) {
+            throw new \LogicException( 'Must specify "cacheFile" option' );
         }
-        return new $options['dispatcher']($dispatchData);
+
+        if (!$options[ 'cacheDisabled' ] && file_exists( $options[ 'cacheFile' ] )) {
+            $dispatchData = require $options[ 'cacheFile' ];
+            if (!is_array( $dispatchData )) {
+                throw new \RuntimeException( 'Invalid cache file "' . $options[ 'cacheFile' ] . '"' );
+            }
+
+            return new $options[ 'dispatcher' ]( $dispatchData );
+        }
+
+        $routeCollector = new RouteCollector(
+            new $options[ 'routeParser' ], new $options[ 'dataGenerator' ]
+        );
+        $routeDefinitionCallback( $routeCollector );
+
+        $dispatchData = $routeCollector->getData();
+        file_put_contents(
+            $options[ 'cacheFile' ],
+            '<?php return ' . var_export( $dispatchData, true ) . ';'
+        );
+
+        return new $options[ 'dispatcher' ]( $dispatchData );
     }
-
-    $routeCollector = new RouteCollector(
-        new $options['routeParser'], new $options['dataGenerator']
-    );
-    $routeDefinitionCallback($routeCollector);
-
-    $dispatchData = $routeCollector->getData();
-    file_put_contents(
-        $options['cacheFile'],
-        '<?php return ' . var_export($dispatchData, true) . ';'
-    );
-
-    return new $options['dispatcher']($dispatchData);
 }


### PR DESCRIPTION
Problem : PHP Fatal error:  Cannot re-declare FastRoute\simpleDispatcher()

When developing a package ( e.g. in Laravel workbench ) that depends on FastRoute, issue occurs when both main project and package have a dependency on FastRoute.

Issue is that  code in functions.php doesn't check if those two functions are already defined, and PHP dies when it tries to include the FastRoute from dev package vendor / FastRoute folder ( as it already is defined in main project vendor / FastRoute ).
