### PR TITLE
Refactoring: dispatch now returns DispatcherResult objects instead of arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*~
+.DS_Store
+Thumbs.db
+/vendor
+/coverage
+/nbproject
+.idea
+.env
+composer.lock
+.phpstorm.meta.php

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -2,24 +2,18 @@
 
 namespace FastRoute;
 
-interface Dispatcher {
-    const NOT_FOUND = 0;
-    const FOUND = 1;
-    const METHOD_NOT_ALLOWED = 2;
+use FastRoute\DispatcherResult\FoundResult;
+use FastRoute\DispatcherResult\MethodNotAllowedResult;
+use FastRoute\DispatcherResult\NotFoundResult;
 
+interface Dispatcher {
     /**
      * Dispatches against the provided HTTP method verb and URI.
-     *
-     * Returns array with one of the following formats:
-     *
-     *     [self::NOT_FOUND]
-     *     [self::METHOD_NOT_ALLOWED, ['GET', 'OTHER_ALLOWED_METHODS']]
-     *     [self::FOUND, $handler, ['varName' => 'value', ...]]
      *
      * @param string $httpMethod
      * @param string $uri
      *
-     * @return array
+     * @return DispatcherResult|FoundResult|NotFoundResult|MethodNotAllowedResult
      */
     public function dispatch($httpMethod, $uri);
 }

--- a/src/Dispatcher/CharCountBased.php
+++ b/src/Dispatcher/CharCountBased.php
@@ -2,6 +2,9 @@
 
 namespace FastRoute\Dispatcher;
 
+use FastRoute\DispatcherResult\FoundResult;
+use FastRoute\DispatcherResult\NotFoundResult;
+
 class CharCountBased extends RegexBasedAbstract {
     public function __construct($data) {
         list($this->staticRouteMap, $this->variableRouteData) = $data;
@@ -20,9 +23,9 @@ class CharCountBased extends RegexBasedAbstract {
             foreach ($varNames as $varName) {
                 $vars[$varName] = $matches[++$i];
             }
-            return [self::FOUND, $handler, $vars];
+            return new FoundResult($handler, $vars);
         }
 
-        return [self::NOT_FOUND];
+        return new NotFoundResult();
     }
 }

--- a/src/Dispatcher/GroupCountBased.php
+++ b/src/Dispatcher/GroupCountBased.php
@@ -2,6 +2,9 @@
 
 namespace FastRoute\Dispatcher;
 
+use FastRoute\DispatcherResult\FoundResult;
+use FastRoute\DispatcherResult\NotFoundResult;
+
 class GroupCountBased extends RegexBasedAbstract {
     public function __construct($data) {
         list($this->staticRouteMap, $this->variableRouteData) = $data;
@@ -20,9 +23,9 @@ class GroupCountBased extends RegexBasedAbstract {
             foreach ($varNames as $varName) {
                 $vars[$varName] = $matches[++$i];
             }
-            return [self::FOUND, $handler, $vars];
+            return new FoundResult($handler, $vars);
         }
 
-        return [self::NOT_FOUND];
+        return new NotFoundResult();
     }
 }

--- a/src/Dispatcher/GroupPosBased.php
+++ b/src/Dispatcher/GroupPosBased.php
@@ -2,6 +2,9 @@
 
 namespace FastRoute\Dispatcher;
 
+use FastRoute\DispatcherResult\FoundResult;
+use FastRoute\DispatcherResult\NotFoundResult;
+
 class GroupPosBased extends RegexBasedAbstract {
     public function __construct($data) {
         list($this->staticRouteMap, $this->variableRouteData) = $data;
@@ -22,9 +25,9 @@ class GroupPosBased extends RegexBasedAbstract {
             foreach ($varNames as $varName) {
                 $vars[$varName] = $matches[$i++];
             }
-            return [self::FOUND, $handler, $vars];
+            return new FoundResult($handler, $vars);
         }
 
-        return [self::NOT_FOUND];
+        return new NotFoundResult();
     }
 }

--- a/src/Dispatcher/MarkBased.php
+++ b/src/Dispatcher/MarkBased.php
@@ -2,6 +2,9 @@
 
 namespace FastRoute\Dispatcher;
 
+use FastRoute\DispatcherResult\FoundResult;
+use FastRoute\DispatcherResult\NotFoundResult;
+
 class MarkBased extends RegexBasedAbstract {
     public function __construct($data) {
         list($this->staticRouteMap, $this->variableRouteData) = $data;
@@ -20,9 +23,9 @@ class MarkBased extends RegexBasedAbstract {
             foreach ($varNames as $varName) {
                 $vars[$varName] = $matches[++$i];
             }
-            return [self::FOUND, $handler, $vars];
+            return new FoundResult($handler, $vars);
         }
 
-        return [self::NOT_FOUND];
+        return new NotFoundResult();
     }
 }

--- a/src/Dispatcher/RegexBasedAbstract.php
+++ b/src/Dispatcher/RegexBasedAbstract.php
@@ -2,32 +2,33 @@
 
 namespace FastRoute\Dispatcher;
 
+use FastRoute\DispatcherResult\FoundResult;
+use FastRoute\DispatcherResult\MethodNotAllowedResult;
+use FastRoute\DispatcherResult\NotFoundResult;
 use FastRoute\Dispatcher;
 
 abstract class RegexBasedAbstract implements Dispatcher {
     protected $staticRouteMap;
     protected $variableRouteData;
 
-    protected abstract function dispatchVariableRoute($routeData, $uri);
-
     public function dispatch($httpMethod, $uri) {
         if (isset($this->staticRouteMap[$httpMethod][$uri])) {
             $handler = $this->staticRouteMap[$httpMethod][$uri];
-            return [self::FOUND, $handler, []];
-        } else if ($httpMethod === 'HEAD' && isset($this->staticRouteMap['GET'][$uri])) {
+            return new FoundResult($handler, []);
+        } elseif ($httpMethod === 'HEAD' && isset($this->staticRouteMap['GET'][$uri])) {
             $handler = $this->staticRouteMap['GET'][$uri];
-            return [self::FOUND, $handler, []];
+            return new FoundResult($handler, []);
         }
 
         $varRouteData = $this->variableRouteData;
         if (isset($varRouteData[$httpMethod])) {
             $result = $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
-            if ($result[0] === self::FOUND) {
+            if ($result instanceof FoundResult) {
                 return $result;
             }
-        } else if ($httpMethod === 'HEAD' && isset($varRouteData['GET'])) {
+        } elseif ($httpMethod === 'HEAD' && isset($varRouteData['GET'])) {
             $result = $this->dispatchVariableRoute($varRouteData['GET'], $uri);
-            if ($result[0] === self::FOUND) {
+            if ($result instanceof FoundResult) {
                 return $result;
             }
         }
@@ -47,16 +48,18 @@ abstract class RegexBasedAbstract implements Dispatcher {
             }
 
             $result = $this->dispatchVariableRoute($routeData, $uri);
-            if ($result[0] === self::FOUND) {
+            if ($result instanceof FoundResult) {
                 $allowedMethods[] = $method;
             }
         }
 
         // If there are no allowed methods the route simply does not exist
         if ($allowedMethods) {
-            return [self::METHOD_NOT_ALLOWED, $allowedMethods];
+            return new MethodNotAllowedResult($allowedMethods);
         } else {
-            return [self::NOT_FOUND];
+            return new NotFoundResult();
         }
     }
+
+    protected abstract function dispatchVariableRoute($routeData, $uri);
 }

--- a/src/DispatcherResult.php
+++ b/src/DispatcherResult.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace FastRoute;
+
+interface DispatcherResult {
+
+}

--- a/src/DispatcherResult/FoundResult.php
+++ b/src/DispatcherResult/FoundResult.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace FastRoute\DispatcherResult;
+
+use FastRoute\DispatcherResult;
+
+class FoundResult implements DispatcherResult {
+    /**
+     * @var mixed
+     */
+    public $handler;
+
+    /**
+     * @var array
+     */
+    public $vars;
+
+    public function __construct($handler, array $vars = []) {
+        $this->handler = $handler;
+        $this->vars  = $vars;
+    }
+
+}

--- a/src/DispatcherResult/MethodNotAllowedResult.php
+++ b/src/DispatcherResult/MethodNotAllowedResult.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FastRoute\DispatcherResult;
+
+use FastRoute\DispatcherResult;
+
+class MethodNotAllowedResult implements DispatcherResult {
+    /**
+     * @var array
+     */
+    public $allowedMethods;
+
+    public function __construct(array $allowedMethods = []) {
+        $this->allowedMethods = $allowedMethods;
+    }
+}

--- a/src/DispatcherResult/NotFoundResult.php
+++ b/src/DispatcherResult/NotFoundResult.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace FastRoute\DispatcherResult;
+
+use FastRoute\DispatcherResult;
+
+class NotFoundResult implements DispatcherResult {
+
+}

--- a/src/Route.php
+++ b/src/Route.php
@@ -12,9 +12,9 @@ class Route {
      * Constructs a route (value object).
      *
      * @param string $httpMethod
-     * @param mixed  $handler
+     * @param mixed $handler
      * @param string $regex
-     * @param array  $variables
+     * @param array $variables
      */
     public function __construct($httpMethod, $handler, $regex, $variables) {
         $this->httpMethod = $httpMethod;
@@ -32,7 +32,7 @@ class Route {
      */
     public function matches($str) {
         $regex = '~^' . $this->regex . '$~';
-        return (bool) preg_match($regex, $str);
+        return (bool)preg_match($regex, $str);
     }
 }
 

--- a/src/RouteParser.php
+++ b/src/RouteParser.php
@@ -14,7 +14,6 @@ interface RouteParser {
      * ]
      *
      * @param string $route Route to parse
-     * 
      * @return array Parsed route data
      */
     public function parse($route);


### PR DESCRIPTION
A little refactoring to make dispatch return value more Object-oriented and easier to use and identify.