### PR TITLE
Fix namespace issue in HHI file

### DIFF
--- a/FastRoute.hhi
+++ b/FastRoute.hhi
@@ -1,6 +1,6 @@
 <?hh // decl
 
-namespace FastRoute;
+namespace FastRoute {
 
 
 class BadRouteException extends \LogicException {
@@ -118,4 +118,6 @@ REGEX;
         const string DEFAULT_DISPATCH_REGEX = '[^/]+';
         public function parse(string $route): array<array>;
     }
+}
+
 }


### PR DESCRIPTION
It appears that a change I made last minute didn't make it :(

Apparently I cannot declare a global namespace when I have namespaces inside of it. I have to enclose it in curly braces.

I am so sorry for the inconvenience.