### PR TITLE
HHI: Change the options arrays for dispatchers to shapes

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -1,0 +1,1 @@
+assume_php=false

--- a/FastRoute.hhi
+++ b/FastRoute.hhi
@@ -34,19 +34,19 @@ namespace FastRoute {
     function simpleDispatcher(
         (function(RouteCollector): void) $routeDefinitionCallback,
         shape(
-          'routeParser' => ?string,
-          'dataGenerator' => ?string,
-          'dispatcher' => ?string,
-          'routeCollector' => ?string,
+          'routeParser' => ?classname<RouteParser>,
+          'dataGenerator' => ?classname<DataGenerator>,
+          'dispatcher' => ?classname<Dispatcher>,
+          'routeCollector' => ?classname<RouteCollector>,
         ) $options = shape()): Dispatcher;
 
     function cachedDispatcher(
         (function(RouteCollector): void) $routeDefinitionCallback,
         shape(
-          'routeParser' => ?string,
-          'dataGenerator' => ?string,
-          'dispatcher' => ?string,
-          'routeCollector' => ?string,
+          'routeParser' => ?classname<RouteParser>,
+          'dataGenerator' => ?classname<DataGenerator>,
+          'dispatcher' => ?classname<Dispatcher>,
+          'routeCollector' => ?classname<RouteCollector>,
           'cacheDisabled' => ?bool,
           'cacheFile' => ?string,
         ) $options = shape()): Dispatcher;

--- a/FastRoute.hhi
+++ b/FastRoute.hhi
@@ -53,7 +53,7 @@ namespace FastRoute {
 }
 
 namespace FastRoute\DataGenerator {
-    abstract class RegexBasedAbstract implements DataGenerator {
+    abstract class RegexBasedAbstract implements \FastRoute\DataGenerator {
         protected abstract function getApproxChunkSize();
         protected abstract function processChunk($regexToRoutesMap);
 
@@ -83,7 +83,7 @@ namespace FastRoute\DataGenerator {
 }
 
 namespace FastRoute\Dispatcher {
-    abstract class RegexBasedAbstract implements Dispatcher {
+    abstract class RegexBasedAbstract implements \FastRoute\Dispatcher {
         protected abstract function dispatchVariableRoute(array<array> $routeData, string $uri): array;
 
         public function dispatch(string $httpMethod, string $uri): array;
@@ -111,7 +111,7 @@ namespace FastRoute\Dispatcher {
 }
 
 namespace FastRoute\RouteParser {
-    class Std implements RouteParser {
+    class Std implements \FastRoute\RouteParser {
         const string VARIABLE_REGEX = <<<'REGEX'
 \{
     \s* ([a-zA-Z][a-zA-Z0-9_]*) \s*

--- a/FastRoute.hhi
+++ b/FastRoute.hhi
@@ -33,11 +33,23 @@ namespace FastRoute {
 
     function simpleDispatcher(
         (function(RouteCollector): void) $routeDefinitionCallback,
-        array<string, string> $options = []): Dispatcher;
+        shape(
+          'routeParser' => ?string,
+          'dataGenerator' => ?string,
+          'dispatcher' => ?string,
+          'routeCollector' => ?string,
+        ) $options = shape()): Dispatcher;
 
     function cachedDispatcher(
         (function(RouteCollector): void) $routeDefinitionCallback,
-        array<string, string> $options = []): Dispatcher;
+        shape(
+          'routeParser' => ?string,
+          'dataGenerator' => ?string,
+          'dispatcher' => ?string,
+          'routeCollector' => ?string,
+          'cacheDisabled' => ?bool,
+          'cacheFile' => ?string,
+        ) $options = shape()): Dispatcher;
 }
 
 namespace FastRoute\DataGenerator {

--- a/test/HackTypechecker/HackTypecheckerTest.php
+++ b/test/HackTypechecker/HackTypecheckerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace FastRoute;
+
+class HackTypecheckerTest extends \PhpUnit_Framework_TestCase {
+    const SERVER_ALREADY_RUNNING_CODE = 77;
+    public function testTypechecks($recurse = true) {
+        if (!defined('HHVM_VERSION')) {
+            $this->markTestSkipped("HHVM only");
+        }
+        if (!version_compare(HHVM_VERSION, '3.9.0', '>=')) {
+          $this->markTestSkipped('classname<T> requires HHVM 3.9+');
+        }
+
+        // The typechecker recurses the whole tree, so it makes sure
+        // that everything in fixtures/ is valid when this runs.
+
+        $output = array();
+        $exit_code = null;
+        exec(
+            'hh_server --check '.escapeshellarg(__DIR__.'/../../').' 2>&1',
+            $output,
+            $exit_code
+        );
+        if ($exit_code === self::SERVER_ALREADY_RUNNING_CODE) {
+            $this->assertTrue(
+              $recurse,
+              "Typechecker still running after running hh_client stop"
+            );
+            // Server already running - 3.10 => 3.11 regression:
+            // https://github.com/facebook/hhvm/issues/6646
+            exec('hh_client stop 2>/dev/null');
+            $this->testTypechecks(/* recurse = */ false);
+            return;
+
+        }
+        $this->assertSame(0, $exit_code, implode("\n", $output));
+    }
+}

--- a/test/HackTypechecker/fixtures/all_options.php
+++ b/test/HackTypechecker/fixtures/all_options.php
@@ -1,0 +1,29 @@
+<?hh
+
+namespace FastRoute\TestFixtures;
+
+function all_options_simple(): \FastRoute\Dispatcher {
+    return \FastRoute\simpleDispatcher(
+      $collector ==> {},
+      shape(
+        'routeParser' => \FastRoute\RouteParser\Std::class,
+        'dataGenerator' => \FastRoute\DataGenerator\GroupCountBased::class,
+        'dispatcher' => \FastRoute\Dispatcher\GroupCountBased::class,
+        'routeCollector' => \FastRoute\RouteCollector::class,
+      ),
+    );
+}
+
+function all_options_cached(): \FastRoute\Dispatcher {
+    return \FastRoute\cachedDispatcher(
+      $collector ==> {},
+      shape(
+        'routeParser' => \FastRoute\RouteParser\Std::class,
+        'dataGenerator' => \FastRoute\DataGenerator\GroupCountBased::class,
+        'dispatcher' => \FastRoute\Dispatcher\GroupCountBased::class,
+        'routeCollector' => \FastRoute\RouteCollector::class,
+        'cacheFile' => '/dev/null',
+        'cacheDisabled' => false,
+      ),
+    );
+}

--- a/test/HackTypechecker/fixtures/empty_options.php
+++ b/test/HackTypechecker/fixtures/empty_options.php
@@ -1,0 +1,11 @@
+<?hh
+
+namespace FastRoute\TestFixtures;
+
+function empty_options_simple(): \FastRoute\Dispatcher {
+    return \FastRoute\simpleDispatcher($collector ==> {}, shape());
+}
+
+function empty_options_cached(): \FastRoute\Dispatcher {
+    return \FastRoute\cachedDispatcher($collector ==> {}, shape());
+}

--- a/test/HackTypechecker/fixtures/no_options.php
+++ b/test/HackTypechecker/fixtures/no_options.php
@@ -1,0 +1,11 @@
+<?hh
+
+namespace FastRoute\TestFixtures;
+
+function no_options_simple(): \FastRoute\Dispatcher {
+    return \FastRoute\simpleDispatcher($collector ==> {});
+}
+
+function no_options_cached(): \FastRoute\Dispatcher {
+    return \FastRoute\cachedDispatcher($collector ==> {});
+}


### PR DESCRIPTION
It's currently not possible to specify the cacheDisabled option, as it
is a bool. To fix, actually define the acceptable options and their
types.

HHVM allows nullable shape fields to not be specified.

This is BC breaking, as it must now be passed in as a shape instead of
an array.

A non-BC-breaking alternative would be to change the array to
`array<string, mixed>` from `array<string, string>`