### PR TITLE
Fixed exemplary array structure of parsed route in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ each route info is again an array of it's parts. The structure is best understoo
     [
         [
             '/user/',
-            ['name', '[^/]+'],
+            ['id', '\d+'],
         ],
         [
             '/user/',
-            ['name', '[^/]+'],
+            ['id', '\d+'],
             '/',
-            ['id', '[0-9]+'],
+            ['name', '[^/]+'],
         ],
     ]
 


### PR DESCRIPTION
This can be confirmed by temporarily adding
```php
[
    '/user/{id:\d+}[/{name}]',
    [
        [
            '/user/',
            ['id', '\d+'],
        ],
        [
            '/user/',
            ['id', '\d+'],
            '/',
            ['name', '[^/]+'],
        ]
    ]
]
```
to `test/RouteParser/StdTest.php`.