### PR TITLE
Added syntactic sugar for route collector

### DIFF
--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -34,6 +34,66 @@ class RouteCollector {
             }
         }
     }
+    
+    /**
+     * Adds a GET route to the collection
+     * 
+     * This is simply an alias of $this->addRoute('GET', $route, $handler)
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function get($route, $handler) {
+        return $this->addRoute('GET', $route, $handler);
+    }
+    
+    /**
+     * Adds a POST route to the collection
+     * 
+     * This is simply an alias of $this->addRoute('POST', $route, $handler)
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function post($route, $handler) {
+        return $this->addRoute('POST', $route, $handler);
+    }
+    
+    /**
+     * Adds a PUT route to the collection
+     * 
+     * This is simply an alias of $this->addRoute('PUT', $route, $handler)
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function put($route, $handler) {
+        return $this->addRoute('PUT', $route, $handler);
+    }
+    
+    /**
+     * Adds a DELETE route to the collection
+     * 
+     * This is simply an alias of $this->addRoute('DELETE', $route, $handler)
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function delete($route, $handler) {
+        return $this->addRoute('DELETE', $route, $handler);
+    }
+    
+    /**
+     * Adds a PATCH route to the collection
+     * 
+     * This is simply an alias of $this->addRoute('PATCH', $route, $handler)
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function patch($route, $handler) {
+        return $this->addRoute('PATCH', $route, $handler);
+    }
 
     /**
      * Returns the collected route data, as provided by the data generator.


### PR DESCRIPTION
Added simpler methods for syntactic sugar for defining routes.

When defining a lot of routes, this saves a lot of typing overhead.