### PR TITLE
Route Group Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,30 @@ The `$handler` parameter does not necessarily have to be a callback, it could al
 class name or any other kind of data you wish to associate with the route. FastRoute only tells you
 which handler corresponds to your URI, how you interpret it is up to you.
 
+#### Route Groups
+
+Additionally, you can specify routes inside of a group. This is useful when you have a lot of routes under a specific url.
+
+E.g. Defining your routes as below...
+
+```php
+$r->addGroup('/admin', function ($r) {
+    $r->addRoute('GET', '/do-something', 'handler');
+    $r->addRoute('GET', '/do-another-thing', 'handler');
+    $r->addRoute('GET', '/do-something-else', 'handler');
+});
+```
+
+... will have the same result as follows...
+
+ ```php
+$r->addRoute('GET', '/admin/do-something', 'handler');
+$r->addRoute('GET', '/admin/do-another-thing', 'handler');
+$r->addRoute('GET', '/admin/do-something-else', 'handler');
+ ```
+
+Sub-groups are also supported.
+
 ### Caching
 
 The reason `simpleDispatcher` accepts a callback for defining the routes is to allow seamless

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -5,6 +5,7 @@ namespace FastRoute;
 class RouteCollector {
     private $routeParser;
     private $dataGenerator;
+    public $currentRouteGroup;
 
     /**
      * Constructs a route collector.
@@ -27,12 +28,73 @@ class RouteCollector {
      * @param mixed  $handler
      */
     public function addRoute($httpMethod, $route, $handler) {
+        $route = $this->prependRouteWithRouteGroup($route);
         $routeDatas = $this->routeParser->parse($route);
         foreach ((array) $httpMethod as $method) {
             foreach ($routeDatas as $routeData) {
                 $this->dataGenerator->addRoute($method, $routeData, $handler);
             }
         }
+    }
+
+    /**
+     * Prepends the route string with the route string specified in the route group.
+     *
+     * @param string $route
+     * @return string
+     */
+    protected function prependRouteWithRouteGroup($route)
+    {
+        return $this->prependRouteWithGroupsRoute($route, $this->currentRouteGroup);
+    }
+
+
+    /**
+     * Prepends the provided route with the route inside the provided route group.
+     *
+     * @param string $route
+     * @param null|\stdClass $group
+     * @return string
+     */
+    private function prependRouteWithGroupsRoute($route, $group)
+    {
+        if (is_object($group)) {
+            $route = "{$group->route}/" . ltrim($route, '/');
+        }
+        return $route;
+    }
+
+    /**
+     * Creates a new route group and returns it.
+     * If a previous group was passed it, it will prepend the groups route with the previous groups route.
+     *
+     * @param string $route
+     * @param callable $callback
+     * @param null|\stdClass $previousGroup
+     * @return \stdClass
+     */
+    private function createGroup($route, callable $callback, $previousGroup) {
+        $route = $this->prependRouteWithGroupsRoute($route, $previousGroup);
+        $group = new \stdClass();
+        $group->route = $route;
+        $group->callback = $callback;
+        $group->groups = [];
+        return $group;
+    }
+
+    /**
+     * Sets up a route group with a callback to allow you to create routes inside that group.
+     *
+     * @param string $route
+     * @param callable $callback
+     */
+    public function addGroup($route, callable $callback)
+    {
+        $route = rtrim($route, '/');
+        $previousGroup = $this->currentRouteGroup;
+        $this->currentRouteGroup = $this->createGroup($route, $callback, $previousGroup);
+        $callback($this);
+        $this->currentRouteGroup = $previousGroup;
     }
     
     /**

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -5,7 +5,7 @@ namespace FastRoute;
 class RouteCollector {
     private $routeParser;
     private $dataGenerator;
-    private $currentRouteGroup;
+    private $currentRouteGroupPrefix;
 
     /**
      * Constructs a route collector.
@@ -45,7 +45,7 @@ class RouteCollector {
      */
     protected function prependRouteWithRouteGroup($route)
     {
-        return $this->prependRouteWithGroupsRoute($route, $this->currentRouteGroup);
+        return $this->prependRouteWithGroupsRoute($route, $this->currentRouteGroupPrefix);
     }
 
 
@@ -53,13 +53,13 @@ class RouteCollector {
      * Prepends the provided route with the route inside the provided route group.
      *
      * @param string $route
-     * @param null|\stdClass $group
+     * @param null|string $groupPrefix
      * @return string
      */
-    private function prependRouteWithGroupsRoute($route, $group)
+    private function prependRouteWithGroupsRoute($route, $groupPrefix)
     {
-        if (is_object($group)) {
-            $route = $group->route . $route;
+        if (! is_null($groupPrefix)) {
+            $route = $groupPrefix . $route;
         }
         return $route;
     }
@@ -69,17 +69,13 @@ class RouteCollector {
      * If a previous group was passed it, it will prepend the groups route with the previous groups route.
      *
      * @param string $route
-     * @param callable $callback
-     * @param null|\stdClass $previousGroup
+     * @param null|string $previousGroupPrefix
      * @return \stdClass
      */
-    private function createGroup($route, callable $callback, $previousGroup) {
-        $route = $this->prependRouteWithGroupsRoute($route, $previousGroup);
-        $group = new \stdClass();
-        $group->route = $route;
-        $group->callback = $callback;
-        $group->groups = [];
-        return $group;
+    private function createGroup($route, $previousGroupPrefix) {
+        $route = $this->prependRouteWithGroupsRoute($route, $previousGroupPrefix);
+        $groupPrefix = $route;
+        return $groupPrefix;
     }
 
     /**
@@ -90,11 +86,10 @@ class RouteCollector {
      */
     public function addGroup($route, callable $callback)
     {
-        $route = rtrim($route, '/');
-        $previousGroup = $this->currentRouteGroup;
-        $this->currentRouteGroup = $this->createGroup($route, $callback, $previousGroup);
+        $previousGroupPrefix = $this->currentRouteGroupPrefix;
+        $this->currentRouteGroupPrefix = $this->createGroup($route, $previousGroupPrefix);
         $callback($this);
-        $this->currentRouteGroup = $previousGroup;
+        $this->currentRouteGroupPrefix = $previousGroupPrefix;
     }
     
     /**

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -5,7 +5,7 @@ namespace FastRoute;
 class RouteCollector {
     private $routeParser;
     private $dataGenerator;
-    public $currentRouteGroup;
+    private $currentRouteGroup;
 
     /**
      * Constructs a route collector.
@@ -59,7 +59,7 @@ class RouteCollector {
     private function prependRouteWithGroupsRoute($route, $group)
     {
         if (is_object($group)) {
-            $route = "{$group->route}/" . ltrim($route, '/');
+            $route = $group->route . $route;
         }
         return $route;
     }

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -53,6 +53,13 @@ class RouteCollectorTest extends \PHPUnit_Framework_TestCase {
             });
         });
 
+        $r->addGroup('/admin', function (DummyRouteCollector $r) {
+            $r->get('-some-info', 'admin-some-info');
+        });
+        $r->addGroup('/admin-', function (DummyRouteCollector $r) {
+            $r->get('more-info', 'admin-more-info');
+        });
+
         $expected = [
             ['DELETE', '/delete', 'delete'],
             ['GET', '/get', 'get'],
@@ -72,6 +79,8 @@ class RouteCollectorTest extends \PHPUnit_Framework_TestCase {
             ['PATCH', '/group-one/group-two/patch', 'patch'],
             ['POST', '/group-one/group-two/post', 'post'],
             ['PUT', '/group-one/group-two/put', 'put'],
+            ['GET', '/admin-some-info', 'admin-some-info'],
+            ['GET', '/admin-more-info', 'admin-more-info'],
         ];
 
         $this->assertSame($expected, $r->routes);

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -24,12 +24,65 @@ class RouteCollectorTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertSame($expected, $r->routes);
     }
+
+    public function testGroups() {
+        $r = new DummyRouteCollector();
+
+        $r->delete('/delete', 'delete');
+        $r->get('/get', 'get');
+        $r->head('/head', 'head');
+        $r->patch('/patch', 'patch');
+        $r->post('/post', 'post');
+        $r->put('/put', 'put');
+
+        $r->addGroup('/group-one', function (DummyRouteCollector $r) {
+            $r->delete('/delete', 'delete');
+            $r->get('/get', 'get');
+            $r->head('/head', 'head');
+            $r->patch('/patch', 'patch');
+            $r->post('/post', 'post');
+            $r->put('/put', 'put');
+
+            $r->addGroup('/group-two', function (DummyRouteCollector $r) {
+                $r->delete('/delete', 'delete');
+                $r->get('/get', 'get');
+                $r->head('/head', 'head');
+                $r->patch('/patch', 'patch');
+                $r->post('/post', 'post');
+                $r->put('/put', 'put');
+            });
+        });
+
+        $expected = [
+            ['DELETE', '/delete', 'delete'],
+            ['GET', '/get', 'get'],
+            ['HEAD', '/head', 'head'],
+            ['PATCH', '/patch', 'patch'],
+            ['POST', '/post', 'post'],
+            ['PUT', '/put', 'put'],
+            ['DELETE', '/group-one/delete', 'delete'],
+            ['GET', '/group-one/get', 'get'],
+            ['HEAD', '/group-one/head', 'head'],
+            ['PATCH', '/group-one/patch', 'patch'],
+            ['POST', '/group-one/post', 'post'],
+            ['PUT', '/group-one/put', 'put'],
+            ['DELETE', '/group-one/group-two/delete', 'delete'],
+            ['GET', '/group-one/group-two/get', 'get'],
+            ['HEAD', '/group-one/group-two/head', 'head'],
+            ['PATCH', '/group-one/group-two/patch', 'patch'],
+            ['POST', '/group-one/group-two/post', 'post'],
+            ['PUT', '/group-one/group-two/put', 'put'],
+        ];
+
+        $this->assertSame($expected, $r->routes);
+    }
 }
 
 class DummyRouteCollector extends RouteCollector {
     public $routes = [];
     public function __construct() {}
     public function addRoute($method, $route, $handler) {
+        $route = $this->prependRouteWithRouteGroup($route);
         $this->routes[] = [$method, $route, $handler];
     }
 }


### PR DESCRIPTION
This PR adds the ability to create groups of routes to save on typing when you have multiple routes under a single "uri group".

E.g.
/admin/users, /admin/posts, /admin/products

Can be reduced to a single group of /admin, with 3 items: /users, /posts, /products.

I have created a new test that is passing, and the README was updated with an example.