### PR TITLE
New OOP approach for Route and ability to set and retrieve extra data at route definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,17 @@ A URI is dispatched by calling the `dispatch()` method of the created dispatcher
 accepts the HTTP method and a URI. Getting those two bits of information (and normalizing them
 appropriately) is your job - this library is not bound to the PHP web SAPIs.
 
-The `dispatch()` method returns an array whose first element contains a status code. It is one
-of `Dispatcher::NOT_FOUND`, `Dispatcher::METHOD_NOT_ALLOWED` and `Dispatcher::FOUND`. For the
-method not allowed status the second array element contains a list of HTTP methods allowed for
-the supplied URI. For example:
+The `dispatch()` method returns an object (see the object structure below). If the route was not
+founded or the HTTP method was not allowed, the `dispatch()` method will throw an exception.
+FastRoute\Exception\HttpNotFoundException or FastRoute\Exception\HttpMethodNotAllowedException.
+For the method not allowed exception you can retrieve a list of HTTP methods allowed for the
+supplied URI using the method `getAllowedMethod()`.
 
-    [FastRoute\Dispatcher::METHOD_NOT_ALLOWED, ['GET', 'POST']]
+```php
+//...
+catch (FastRoute\Exception\HttpMethodNotAllowedException $e) {
+    $allowedMethods = $e->getAllowedMethod();
+}
 
 > **NOTE:** The HTTP specification requires that a `405 Method Not Allowed` response include the
 `Allow:` header to detail available methods for the requested resource. Applications using FastRoute
@@ -211,9 +216,28 @@ should use the second array element to add this header when relaying a 405 respo
 For the found status the second array element is the handler that was associated with the route
 and the third array element is a dictionary of placeholder names to their values. For example:
 
-    /* Routing against GET /user/nikic/42 */
+```php
+/* Routing against GET /user/nikic/42 */
 
-    [FastRoute\Dispatcher::FOUND, 'handler0', ['name' => 'nikic', 'id' => '42']]
+object(FastRoute\Route)#7 (5) {
+  ["httpMethod"]=>
+  string(3) "GET"
+  ["regex"]=>
+  string(21) "/user/([^/]+)/([^/]+)"
+  ["variables"]=>
+  array(2) {
+    ["name"]=>
+    string(5) "nikic"
+    ["id"]=>
+    string(2) "42"
+  }
+  ["handler"]=>
+  string(8) "handler0"
+  ["data"]=>
+  array(0) {
+  }
+}
+```
 
 ### Overriding the route parser and dispatcher
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ try {
     $handler = $routeInfo->handler;
     $vars = $routeInfo->variables;
 
-    if (in_array('auth', $routeInfo->data]) {
+    if (in_array('auth', $routeInfo->data)) {
         // Check if current user is authenticated before continue
     }
     
@@ -188,6 +188,8 @@ $dispatcher = FastRoute\cachedDispatcher(function(FastRoute\RouteCollector $r) {
 
 The second parameter to the function is an options array, which can be used to specify the cache
 file location, among other things.
+
+CAUTION: You can't cache routes with handlers as Closures.
 
 ### Dispatching a URI
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ supplied URI using the method `getAllowedMethod()`.
 catch (FastRoute\Exception\HttpMethodNotAllowedException $e) {
     $allowedMethods = $e->getAllowedMethod();
 }
+```
 
 > **NOTE:** The HTTP specification requires that a `405 Method Not Allowed` response include the
 `Allow:` header to detail available methods for the requested resource. Applications using FastRoute
@@ -254,7 +255,7 @@ interface RouteParser {
 }
 
 interface DataGenerator {
-    public function addRoute($httpMethod, $routeData, $handler);
+    public function addRoute($httpMethod, $routeData, $handler, array $data = []);
     public function getData();
 }
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pedrofaria/fast-route",
+  "name": "nikic/fast-route",
   "description": "Fast request router for PHP",
   "keywords": ["routing", "router"],
   "license": "BSD-3-Clause",
@@ -7,10 +7,6 @@
     {
       "name": "Nikita Popov",
       "email": "nikic@php.net"
-    },
-    {
-      "name": "Pedro Faria",
-      "email": "eu@eusouopedro.com"
     }
   ],
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
   "require": {
     "php": ">=5.4.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "5.5.*"
+  },
   "autoload": {
     "psr-4": {
       "FastRoute\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pedrofaria/fastroute",
+  "name": "pedrofaria/fast-route",
   "description": "Fast request router for PHP",
   "keywords": ["routing", "router"],
   "license": "BSD-3-Clause",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     {
       "name": "Pedro Faria",
       "email": "eu@eusouopedro.com"
-    },
+    }
   ],
   "require": {
     "php": ">=5.4.0"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "nikic/fast-route",
+  "name": "pedrofaria/fastroute",
   "description": "Fast request router for PHP",
   "keywords": ["routing", "router"],
   "license": "BSD-3-Clause",
@@ -7,7 +7,11 @@
     {
       "name": "Nikita Popov",
       "email": "nikic@php.net"
-    }
+    },
+    {
+      "name": "Pedro Faria",
+      "email": "eu@eusouopedro.com"
+    },
   ],
   "require": {
     "php": ">=5.4.0"

--- a/src/DataGenerator.php
+++ b/src/DataGenerator.php
@@ -14,6 +14,7 @@ interface DataGenerator {
      * @param string $httpMethod
      * @param array $routeData
      * @param mixed $handler
+     * @param array $data
      */
     public function addRoute($httpMethod, $routeData, $handler, array $data = []);
 

--- a/src/DataGenerator.php
+++ b/src/DataGenerator.php
@@ -15,7 +15,7 @@ interface DataGenerator {
      * @param array $routeData
      * @param mixed $handler
      */
-    public function addRoute($httpMethod, $routeData, $handler);
+    public function addRoute($httpMethod, $routeData, $handler, array $data = []);
 
     /**
      * Returns dispatcher data in some unspecified format, which

--- a/src/DataGenerator/CharCountBased.php
+++ b/src/DataGenerator/CharCountBased.php
@@ -19,7 +19,7 @@ class CharCountBased extends RegexBasedAbstract {
             $suffix .= "\t";
 
             $regexes[] = '(?:' . $regex . '/(\t{' . $suffixLen . '})\t{' . ($count - $suffixLen) . '})';
-            $routeMap[$suffix] = [$route->handler, $route->variables];
+            $routeMap[$suffix] = $route;
         }
 
         $regex = '~^(?|' . implode('|', $regexes) . ')$~';

--- a/src/DataGenerator/GroupCountBased.php
+++ b/src/DataGenerator/GroupCountBased.php
@@ -16,7 +16,7 @@ class GroupCountBased extends RegexBasedAbstract {
             $numGroups = max($numGroups, $numVariables);
 
             $regexes[] = $regex . str_repeat('()', $numGroups - $numVariables);
-            $routeMap[$numGroups + 1] = [$route->handler, $route->variables];
+            $routeMap[$numGroups + 1] = $route;
 
             ++$numGroups;
         }

--- a/src/DataGenerator/GroupPosBased.php
+++ b/src/DataGenerator/GroupPosBased.php
@@ -13,7 +13,7 @@ class GroupPosBased extends RegexBasedAbstract {
         $offset = 1;
         foreach ($regexToRoutesMap as $regex => $route) {
             $regexes[] = $regex;
-            $routeMap[$offset] = [$route->handler, $route->variables];
+            $routeMap[$offset] = $route;
 
             $offset += count($route->variables);
         }

--- a/src/DataGenerator/MarkBased.php
+++ b/src/DataGenerator/MarkBased.php
@@ -13,7 +13,7 @@ class MarkBased extends RegexBasedAbstract {
         $markName = 'a';
         foreach ($regexToRoutesMap as $regex => $route) {
             $regexes[] = $regex . '(*MARK:' . $markName . ')';
-            $routeMap[$markName] = [$route->handler, $route->variables];
+            $routeMap[$markName] = $route;
 
             ++$markName;
         }

--- a/src/DataGenerator/RegexBasedAbstract.php
+++ b/src/DataGenerator/RegexBasedAbstract.php
@@ -3,7 +3,7 @@
 namespace FastRoute\DataGenerator;
 
 use FastRoute\DataGenerator;
-use FastRoute\BadRouteException;
+use FastRoute\Exception\BadRouteException;
 use FastRoute\Route;
 
 abstract class RegexBasedAbstract implements DataGenerator {
@@ -13,11 +13,11 @@ abstract class RegexBasedAbstract implements DataGenerator {
     protected abstract function getApproxChunkSize();
     protected abstract function processChunk($regexToRoutesMap);
 
-    public function addRoute($httpMethod, $routeData, $handler) {
+    public function addRoute($httpMethod, $routeData, $handler, array $data = []) {
         if ($this->isStaticRoute($routeData)) {
-            $this->addStaticRoute($httpMethod, $routeData, $handler);
+            $this->addStaticRoute($httpMethod, $routeData, $handler, $data);
         } else {
-            $this->addVariableRoute($httpMethod, $routeData, $handler);
+            $this->addVariableRoute($httpMethod, $routeData, $handler, $data);
         }
     }
 
@@ -48,7 +48,7 @@ abstract class RegexBasedAbstract implements DataGenerator {
         return count($routeData) === 1 && is_string($routeData[0]);
     }
 
-    private function addStaticRoute($httpMethod, $routeData, $handler) {
+    private function addStaticRoute($httpMethod, $routeData, $handler, array $data = []) {
         $routeStr = $routeData[0];
 
         if (isset($this->staticRoutes[$httpMethod][$routeStr])) {
@@ -69,10 +69,13 @@ abstract class RegexBasedAbstract implements DataGenerator {
             }
         }
 
-        $this->staticRoutes[$httpMethod][$routeStr] = $handler;
+        // $this->staticRoutes[$httpMethod][$routeStr] = $handler;
+        $this->staticRoutes[$httpMethod][$routeStr] = new Route(
+            $httpMethod, $handler, $data
+        );
     }
 
-    private function addVariableRoute($httpMethod, $routeData, $handler) {
+    private function addVariableRoute($httpMethod, $routeData, $handler, $data) {
         list($regex, $variables) = $this->buildRegexForRoute($routeData);
 
         if (isset($this->methodToRegexToRoutesMap[$httpMethod][$regex])) {
@@ -83,7 +86,7 @@ abstract class RegexBasedAbstract implements DataGenerator {
         }
 
         $this->methodToRegexToRoutesMap[$httpMethod][$regex] = new Route(
-            $httpMethod, $handler, $regex, $variables
+            $httpMethod, $handler, $data, $regex, $variables
         );
     }
 

--- a/src/Dispatcher/CharCountBased.php
+++ b/src/Dispatcher/CharCountBased.php
@@ -13,16 +13,17 @@ class CharCountBased extends RegexBasedAbstract {
                 continue;
             }
 
-            list($handler, $varNames) = $data['routeMap'][end($matches)];
+            $route = $data['routeMap'][end($matches)];
 
             $vars = [];
             $i = 0;
             foreach ($varNames as $varName) {
                 $vars[$varName] = $matches[++$i];
             }
-            return [self::FOUND, $handler, $vars];
+            $route->variables = $vars;
+            return $route;
         }
 
-        return [self::NOT_FOUND];
+        throw new HttpNotFoundException;
     }
 }

--- a/src/Dispatcher/CharCountBased.php
+++ b/src/Dispatcher/CharCountBased.php
@@ -2,6 +2,8 @@
 
 namespace FastRoute\Dispatcher;
 
+use FastRoute\Exception\HttpNotFoundException;
+
 class CharCountBased extends RegexBasedAbstract {
     public function __construct($data) {
         list($this->staticRouteMap, $this->variableRouteData) = $data;
@@ -17,7 +19,7 @@ class CharCountBased extends RegexBasedAbstract {
 
             $vars = [];
             $i = 0;
-            foreach ($varNames as $varName) {
+            foreach ($route->variables as $varName) {
                 $vars[$varName] = $matches[++$i];
             }
             $route->variables = $vars;

--- a/src/Dispatcher/GroupCountBased.php
+++ b/src/Dispatcher/GroupCountBased.php
@@ -2,6 +2,8 @@
 
 namespace FastRoute\Dispatcher;
 
+use FastRoute\Exception\HttpNotFoundException;
+
 class GroupCountBased extends RegexBasedAbstract {
     public function __construct($data) {
         list($this->staticRouteMap, $this->variableRouteData) = $data;
@@ -13,16 +15,18 @@ class GroupCountBased extends RegexBasedAbstract {
                 continue;
             }
 
-            list($handler, $varNames) = $data['routeMap'][count($matches)];
+            // list($handler, $varNames) = $data['routeMap'][count($matches)];
+            $route = $data['routeMap'][count($matches)];
 
             $vars = [];
             $i = 0;
-            foreach ($varNames as $varName) {
+            foreach ($route->variables as $varName) {
                 $vars[$varName] = $matches[++$i];
             }
-            return [self::FOUND, $handler, $vars];
+            $route->variables = $vars;
+            return $route;
         }
 
-        return [self::NOT_FOUND];
+        throw new HttpNotFoundException;
     }
 }

--- a/src/Dispatcher/GroupPosBased.php
+++ b/src/Dispatcher/GroupPosBased.php
@@ -16,15 +16,16 @@ class GroupPosBased extends RegexBasedAbstract {
             // find first non-empty match
             for ($i = 1; '' === $matches[$i]; ++$i);
 
-            list($handler, $varNames) = $data['routeMap'][$i];
+            $route = $data['routeMap'][$i];
 
             $vars = [];
             foreach ($varNames as $varName) {
                 $vars[$varName] = $matches[$i++];
             }
-            return [self::FOUND, $handler, $vars];
+            $route->variables = $vars;
+            return $route;
         }
 
-        return [self::NOT_FOUND];
+        throw new HttpNotFoundException;
     }
 }

--- a/src/Dispatcher/GroupPosBased.php
+++ b/src/Dispatcher/GroupPosBased.php
@@ -2,6 +2,8 @@
 
 namespace FastRoute\Dispatcher;
 
+use FastRoute\Exception\HttpNotFoundException;
+
 class GroupPosBased extends RegexBasedAbstract {
     public function __construct($data) {
         list($this->staticRouteMap, $this->variableRouteData) = $data;
@@ -19,7 +21,7 @@ class GroupPosBased extends RegexBasedAbstract {
             $route = $data['routeMap'][$i];
 
             $vars = [];
-            foreach ($varNames as $varName) {
+            foreach ($route->variables as $varName) {
                 $vars[$varName] = $matches[$i++];
             }
             $route->variables = $vars;

--- a/src/Dispatcher/MarkBased.php
+++ b/src/Dispatcher/MarkBased.php
@@ -13,16 +13,17 @@ class MarkBased extends RegexBasedAbstract {
                 continue;
             }
 
-            list($handler, $varNames) = $data['routeMap'][$matches['MARK']];
+            $route = $data['routeMap'][$matches['MARK']];
 
             $vars = [];
             $i = 0;
             foreach ($varNames as $varName) {
                 $vars[$varName] = $matches[++$i];
             }
-            return [self::FOUND, $handler, $vars];
+            $route->variables = $vars;
+            return $route;
         }
 
-        return [self::NOT_FOUND];
+        throw new HttpNotFoundException;
     }
 }

--- a/src/Dispatcher/MarkBased.php
+++ b/src/Dispatcher/MarkBased.php
@@ -2,6 +2,8 @@
 
 namespace FastRoute\Dispatcher;
 
+use FastRoute\Exception\HttpNotFoundException;
+
 class MarkBased extends RegexBasedAbstract {
     public function __construct($data) {
         list($this->staticRouteMap, $this->variableRouteData) = $data;
@@ -17,7 +19,7 @@ class MarkBased extends RegexBasedAbstract {
 
             $vars = [];
             $i = 0;
-            foreach ($varNames as $varName) {
+            foreach ($route->variables as $varName) {
                 $vars[$varName] = $matches[++$i];
             }
             $route->variables = $vars;

--- a/src/Dispatcher/RegexBasedAbstract.php
+++ b/src/Dispatcher/RegexBasedAbstract.php
@@ -3,6 +3,8 @@
 namespace FastRoute\Dispatcher;
 
 use FastRoute\Dispatcher;
+use FastRoute\Exception\HttpMethodNotAllowedException;
+use FastRoute\Exception\HttpNotFoundException;
 
 abstract class RegexBasedAbstract implements Dispatcher {
     protected $staticRouteMap;
@@ -12,42 +14,31 @@ abstract class RegexBasedAbstract implements Dispatcher {
 
     public function dispatch($httpMethod, $uri) {
         if (isset($this->staticRouteMap[$httpMethod][$uri])) {
-            $handler = $this->staticRouteMap[$httpMethod][$uri];
-            return [self::FOUND, $handler, []];
+            return $this->staticRouteMap[$httpMethod][$uri];
         }
 
         $varRouteData = $this->variableRouteData;
         if (isset($varRouteData[$httpMethod])) {
-            $result = $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
-            if ($result[0] === self::FOUND) {
-                return $result;
-            }
+            return $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
         }
 
         // For HEAD requests, attempt fallback to GET
         if ($httpMethod === 'HEAD') {
             if (isset($this->staticRouteMap['GET'][$uri])) {
-                $handler = $this->staticRouteMap['GET'][$uri];
-                return [self::FOUND, $handler, []];
+                $route = $this->staticRouteMap['GET'][$uri];
+                return $route;
             }
             if (isset($varRouteData['GET'])) {
-                $result = $this->dispatchVariableRoute($varRouteData['GET'], $uri);
-                if ($result[0] === self::FOUND) {
-                    return $result;
-                }
+                return $this->dispatchVariableRoute($varRouteData['GET'], $uri);
             }
         }
 
         // If nothing else matches, try fallback routes
         if (isset($this->staticRouteMap['*'][$uri])) {
-            $handler = $this->staticRouteMap['*'][$uri];
-            return [self::FOUND, $handler, []];
+            return $this->staticRouteMap['*'][$uri];
         }
         if (isset($varRouteData['*'])) {
-            $result = $this->dispatchVariableRoute($varRouteData['*'], $uri);
-            if ($result[0] === self::FOUND) {
-                return $result;
-            }
+            return $this->dispatchVariableRoute($varRouteData['*'], $uri);
         }
 
         // Find allowed methods for this URI by matching against all other HTTP methods as well
@@ -64,17 +55,18 @@ abstract class RegexBasedAbstract implements Dispatcher {
                 continue;
             }
 
-            $result = $this->dispatchVariableRoute($routeData, $uri);
-            if ($result[0] === self::FOUND) {
-                $allowedMethods[] = $method;
-            }
+            try {
+                $route = $this->dispatchVariableRoute($routeData, $uri);
+                $allowedMethods[] = $route->httpMethod;
+            } catch (\Exception $e) {}
+            
         }
 
         // If there are no allowed methods the route simply does not exist
         if ($allowedMethods) {
-            return [self::METHOD_NOT_ALLOWED, $allowedMethods];
+            throw new HttpMethodNotAllowedException($allowedMethods);
         } else {
-            return [self::NOT_FOUND];
+            throw new HttpNotFoundException;
         }
     }
 }

--- a/src/Dispatcher/RegexBasedAbstract.php
+++ b/src/Dispatcher/RegexBasedAbstract.php
@@ -13,14 +13,16 @@ abstract class RegexBasedAbstract implements Dispatcher {
     protected abstract function dispatchVariableRoute($routeData, $uri);
 
     public function dispatch($httpMethod, $uri) {
-        if (isset($this->staticRouteMap[$httpMethod][$uri])) {
-            return $this->staticRouteMap[$httpMethod][$uri];
-        }
+        try {
+            if (isset($this->staticRouteMap[$httpMethod][$uri])) {
+                return $this->staticRouteMap[$httpMethod][$uri];
+            }
 
-        $varRouteData = $this->variableRouteData;
-        if (isset($varRouteData[$httpMethod])) {
-            return $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
-        }
+            $varRouteData = $this->variableRouteData;
+            if (isset($varRouteData[$httpMethod])) {
+                return $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
+            }
+        } catch (HttpNotFoundException $e) {}
 
         // For HEAD requests, attempt fallback to GET
         if ($httpMethod === 'HEAD') {

--- a/src/Exception/BadRouteException.php
+++ b/src/Exception/BadRouteException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace FastRoute;
+namespace FastRoute\Exception;
 
 class BadRouteException extends \LogicException {
 }

--- a/src/Exception/HttpMethodNotAllowedException.php
+++ b/src/Exception/HttpMethodNotAllowedException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace FastRoute\Exception;
+
+class HttpMethodNotAllowedException extends \Exception {
+    protected $allowedMethods = [];
+
+    public function __construct($allowedMethods = [])
+    {
+        $this->allowedMethods = $allowedMethods;
+    }
+
+    public function getAllowedMethod()
+    {
+        return $this->allowedMethods;
+    }
+}

--- a/src/Exception/HttpNotFoundException.php
+++ b/src/Exception/HttpNotFoundException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace FastRoute\Exception;
+
+class HttpNotFoundException extends \Exception {}

--- a/src/Route.php
+++ b/src/Route.php
@@ -7,6 +7,7 @@ class Route {
     public $regex;
     public $variables;
     public $handler;
+    public $data;
 
     /**
      * Constructs a route (value object).
@@ -16,9 +17,10 @@ class Route {
      * @param string $regex
      * @param array  $variables
      */
-    public function __construct($httpMethod, $handler, $regex, $variables) {
+    public function __construct($httpMethod, $handler, array $data = [], $regex = null, $variables = []) {
         $this->httpMethod = $httpMethod;
         $this->handler = $handler;
+        $this->data = $data;
         $this->regex = $regex;
         $this->variables = $variables;
     }

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -32,7 +32,7 @@ class RouteCollector {
     public function addRoute($httpMethod, $route, $handler, array $data = []) {
         $route = $this->currentGroupPrefix . $route;
         $routeDatas = $this->routeParser->parse($route);
-        $data = array_merge($data, $this->currentGroupData);
+        $data = array_merge($this->currentGroupData, $data);
         foreach ((array) $httpMethod as $method) {
             foreach ($routeDatas as $routeData) {
                 $this->dataGenerator->addRoute($method, $routeData, $handler, $data);
@@ -52,7 +52,7 @@ class RouteCollector {
         $previousGroupPrefix = $this->currentGroupPrefix;
         $this->currentGroupPrefix = $previousGroupPrefix . $prefix;
         $previousGroupData = $this->currentGroupData;
-        $this->currentGroupData = $previousGroupData + $data;
+        $this->currentGroupData = array_merge($previousGroupData, $data);
         $callback($this);
         $this->currentGroupPrefix = $previousGroupPrefix;
         $this->currentGroupData = $previousGroupData;

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -28,6 +28,7 @@ class RouteCollector {
      * @param string|string[] $httpMethod
      * @param string $route
      * @param mixed  $handler
+     * @param array  $data
      */
     public function addRoute($httpMethod, $route, $handler, array $data = []) {
         $route = $this->currentGroupPrefix . $route;
@@ -47,6 +48,7 @@ class RouteCollector {
      *
      * @param string $prefix
      * @param callable $callback
+     * @param array    $data
      */
     public function addGroup($prefix, callable $callback, array $data = []) {
         $previousGroupPrefix = $this->currentGroupPrefix;
@@ -65,6 +67,7 @@ class RouteCollector {
      *
      * @param string $route
      * @param mixed  $handler
+     * @param array  $data
      */
     public function get($route, $handler, array $data = []) {
         $this->addRoute('GET', $route, $handler, $data);
@@ -77,6 +80,7 @@ class RouteCollector {
      *
      * @param string $route
      * @param mixed  $handler
+     * @param array  $data
      */
     public function post($route, $handler, array $data = []) {
         $this->addRoute('POST', $route, $handler, $data);
@@ -89,6 +93,7 @@ class RouteCollector {
      *
      * @param string $route
      * @param mixed  $handler
+     * @param array  $data
      */
     public function put($route, $handler, array $data = []) {
         $this->addRoute('PUT', $route, $handler, $data);
@@ -101,6 +106,7 @@ class RouteCollector {
      *
      * @param string $route
      * @param mixed  $handler
+     * @param array  $data
      */
     public function delete($route, $handler, array $data = []) {
         $this->addRoute('DELETE', $route, $handler, $data);
@@ -113,6 +119,7 @@ class RouteCollector {
      *
      * @param string $route
      * @param mixed  $handler
+     * @param array  $data
      */
     public function patch($route, $handler, array $data = []) {
         $this->addRoute('PATCH', $route, $handler, $data);
@@ -125,6 +132,7 @@ class RouteCollector {
      *
      * @param string $route
      * @param mixed  $handler
+     * @param array  $data
      */
     public function head($route, $handler, array $data = []) {
         $this->addRoute('HEAD', $route, $handler, $data);

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -6,6 +6,7 @@ class RouteCollector {
     protected $routeParser;
     protected $dataGenerator;
     protected $currentGroupPrefix;
+    protected $currentGroupData = [];
 
     /**
      * Constructs a route collector.
@@ -28,12 +29,13 @@ class RouteCollector {
      * @param string $route
      * @param mixed  $handler
      */
-    public function addRoute($httpMethod, $route, $handler) {
+    public function addRoute($httpMethod, $route, $handler, array $data = []) {
         $route = $this->currentGroupPrefix . $route;
         $routeDatas = $this->routeParser->parse($route);
+        $data = array_merge($data, $this->currentGroupData);
         foreach ((array) $httpMethod as $method) {
             foreach ($routeDatas as $routeData) {
-                $this->dataGenerator->addRoute($method, $routeData, $handler);
+                $this->dataGenerator->addRoute($method, $routeData, $handler, $data);
             }
         }
     }
@@ -46,11 +48,14 @@ class RouteCollector {
      * @param string $prefix
      * @param callable $callback
      */
-    public function addGroup($prefix, callable $callback) {
+    public function addGroup($prefix, callable $callback, array $data = []) {
         $previousGroupPrefix = $this->currentGroupPrefix;
         $this->currentGroupPrefix = $previousGroupPrefix . $prefix;
+        $previousGroupData = $this->currentGroupData;
+        $this->currentGroupData = $previousGroupData + $data;
         $callback($this);
         $this->currentGroupPrefix = $previousGroupPrefix;
+        $this->currentGroupData = $previousGroupData;
     }
     
     /**
@@ -61,8 +66,8 @@ class RouteCollector {
      * @param string $route
      * @param mixed  $handler
      */
-    public function get($route, $handler) {
-        $this->addRoute('GET', $route, $handler);
+    public function get($route, $handler, array $data = []) {
+        $this->addRoute('GET', $route, $handler, $data);
     }
     
     /**
@@ -73,8 +78,8 @@ class RouteCollector {
      * @param string $route
      * @param mixed  $handler
      */
-    public function post($route, $handler) {
-        $this->addRoute('POST', $route, $handler);
+    public function post($route, $handler, array $data = []) {
+        $this->addRoute('POST', $route, $handler, $data);
     }
     
     /**
@@ -85,8 +90,8 @@ class RouteCollector {
      * @param string $route
      * @param mixed  $handler
      */
-    public function put($route, $handler) {
-        $this->addRoute('PUT', $route, $handler);
+    public function put($route, $handler, array $data = []) {
+        $this->addRoute('PUT', $route, $handler, $data);
     }
     
     /**
@@ -97,8 +102,8 @@ class RouteCollector {
      * @param string $route
      * @param mixed  $handler
      */
-    public function delete($route, $handler) {
-        $this->addRoute('DELETE', $route, $handler);
+    public function delete($route, $handler, array $data = []) {
+        $this->addRoute('DELETE', $route, $handler, $data);
     }
     
     /**
@@ -109,8 +114,8 @@ class RouteCollector {
      * @param string $route
      * @param mixed  $handler
      */
-    public function patch($route, $handler) {
-        $this->addRoute('PATCH', $route, $handler);
+    public function patch($route, $handler, array $data = []) {
+        $this->addRoute('PATCH', $route, $handler, $data);
     }
 
     /**
@@ -121,8 +126,8 @@ class RouteCollector {
      * @param string $route
      * @param mixed  $handler
      */
-    public function head($route, $handler) {
-        $this->addRoute('HEAD', $route, $handler);
+    public function head($route, $handler, array $data = []) {
+        $this->addRoute('HEAD', $route, $handler, $data);
     }
 
     /**

--- a/src/RouteParser/Std.php
+++ b/src/RouteParser/Std.php
@@ -2,7 +2,7 @@
 
 namespace FastRoute\RouteParser;
 
-use FastRoute\BadRouteException;
+use FastRoute\Exception\BadRouteException;
 use FastRoute\RouteParser;
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -46,7 +46,9 @@ if (!function_exists('FastRoute\simpleDispatcher')) {
         }
 
         if (!$options['cacheDisabled'] && file_exists($options['cacheFile'])) {
-            $dispatchData = require $options['cacheFile'];
+            $cachedData = file_get_contents($options['cacheFile']);
+            $dispatchData = unserialize($cachedData);
+            
             if (!is_array($dispatchData)) {
                 throw new \RuntimeException('Invalid cache file "' . $options['cacheFile'] . '"');
             }
@@ -63,7 +65,7 @@ if (!function_exists('FastRoute\simpleDispatcher')) {
         if (!$options['cacheDisabled']) {
             file_put_contents(
                 $options['cacheFile'],
-                '<?php return ' . var_export($dispatchData, true) . ';'
+                serialize($dispatchData)
             );
         }
 

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -90,7 +90,7 @@ class RouteCollectorTest extends \PHPUnit_Framework_TestCase {
 class DummyRouteCollector extends RouteCollector {
     public $routes = [];
     public function __construct() {}
-    public function addRoute($method, $route, $handler) {
+    public function addRoute($method, $route, $handler, array $data = []) {
         $route = $this->currentGroupPrefix . $route;
         $this->routes[] = [$method, $route, $handler];
     }

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -6,20 +6,20 @@ class RouteCollectorTest extends \PHPUnit_Framework_TestCase {
     public function testShortcuts() {
         $r = new DummyRouteCollector();
 
-        $r->delete('/delete', 'delete');
+        $r->delete('/delete', 'delete', ['dataDel']);
         $r->get('/get', 'get');
-        $r->head('/head', 'head');
+        $r->head('/head', 'head', ['dataHead1', 'dataHead2']);
         $r->patch('/patch', 'patch');
-        $r->post('/post', 'post');
+        $r->post('/post', 'post', []);
         $r->put('/put', 'put');
 
         $expected = [
-            ['DELETE', '/delete', 'delete'],
-            ['GET', '/get', 'get'],
-            ['HEAD', '/head', 'head'],
-            ['PATCH', '/patch', 'patch'],
-            ['POST', '/post', 'post'],
-            ['PUT', '/put', 'put'],
+            ['DELETE', '/delete', 'delete', ['dataDel']],
+            ['GET', '/get', 'get', []],
+            ['HEAD', '/head', 'head', ['dataHead1', 'dataHead2']],
+            ['PATCH', '/patch', 'patch', []],
+            ['POST', '/post', 'post', []],
+            ['PUT', '/put', 'put', []],
         ];
 
         $this->assertSame($expected, $r->routes);
@@ -41,7 +41,7 @@ class RouteCollectorTest extends \PHPUnit_Framework_TestCase {
             $r->head('/head', 'head');
             $r->patch('/patch', 'patch');
             $r->post('/post', 'post');
-            $r->put('/put', 'put');
+            $r->put('/put', 'put', ['put']);
 
             $r->addGroup('/group-two', function (DummyRouteCollector $r) {
                 $r->delete('/delete', 'delete');
@@ -49,9 +49,9 @@ class RouteCollectorTest extends \PHPUnit_Framework_TestCase {
                 $r->head('/head', 'head');
                 $r->patch('/patch', 'patch');
                 $r->post('/post', 'post');
-                $r->put('/put', 'put');
-            });
-        });
+                $r->put('/put', 'put', ['put']);
+            }, ['g2']);
+        }, ['g1']);
 
         $r->addGroup('/admin', function (DummyRouteCollector $r) {
             $r->get('-some-info', 'admin-some-info');
@@ -61,26 +61,55 @@ class RouteCollectorTest extends \PHPUnit_Framework_TestCase {
         });
 
         $expected = [
-            ['DELETE', '/delete', 'delete'],
-            ['GET', '/get', 'get'],
-            ['HEAD', '/head', 'head'],
-            ['PATCH', '/patch', 'patch'],
-            ['POST', '/post', 'post'],
-            ['PUT', '/put', 'put'],
-            ['DELETE', '/group-one/delete', 'delete'],
-            ['GET', '/group-one/get', 'get'],
-            ['HEAD', '/group-one/head', 'head'],
-            ['PATCH', '/group-one/patch', 'patch'],
-            ['POST', '/group-one/post', 'post'],
-            ['PUT', '/group-one/put', 'put'],
-            ['DELETE', '/group-one/group-two/delete', 'delete'],
-            ['GET', '/group-one/group-two/get', 'get'],
-            ['HEAD', '/group-one/group-two/head', 'head'],
-            ['PATCH', '/group-one/group-two/patch', 'patch'],
-            ['POST', '/group-one/group-two/post', 'post'],
-            ['PUT', '/group-one/group-two/put', 'put'],
-            ['GET', '/admin-some-info', 'admin-some-info'],
-            ['GET', '/admin-more-info', 'admin-more-info'],
+            ['DELETE', '/delete', 'delete', []],
+            ['GET', '/get', 'get', []],
+            ['HEAD', '/head', 'head', []],
+            ['PATCH', '/patch', 'patch', []],
+            ['POST', '/post', 'post', []],
+            ['PUT', '/put', 'put', []],
+            ['DELETE', '/group-one/delete', 'delete', ['g1']],
+            ['GET', '/group-one/get', 'get', ['g1']],
+            ['HEAD', '/group-one/head', 'head', ['g1']],
+            ['PATCH', '/group-one/patch', 'patch', ['g1']],
+            ['POST', '/group-one/post', 'post', ['g1']],
+            ['PUT', '/group-one/put', 'put', ['g1', 'put']],
+            ['DELETE', '/group-one/group-two/delete', 'delete', ['g1', 'g2']],
+            ['GET', '/group-one/group-two/get', 'get', ['g1', 'g2']],
+            ['HEAD', '/group-one/group-two/head', 'head', ['g1', 'g2']],
+            ['PATCH', '/group-one/group-two/patch', 'patch', ['g1', 'g2']],
+            ['POST', '/group-one/group-two/post', 'post', ['g1', 'g2']],
+            ['PUT', '/group-one/group-two/put', 'put', ['g1', 'g2', 'put']],
+            ['GET', '/admin-some-info', 'admin-some-info', []],
+            ['GET', '/admin-more-info', 'admin-more-info', []],
+        ];
+
+        $this->assertSame($expected, $r->routes);
+    }
+
+    public function testGroupDataOverride()
+    {
+        $r = new DummyRouteCollector();
+
+        $r->addGroup('/g1', function(DummyRouteCollector $r) {
+            $r->get('/get', 'get');
+            $r->put('/put', 'put', ['data' => 'put']);
+        }, ['data' => 'g1']);
+
+        $r->addGroup('/g2', function(DummyRouteCollector $r) {
+            $r->get('/get', 'get', ['dt' => ['dt' => 'bar'], 'foo' => 'bar']);
+            $r->put('/put', 'put');
+        }, ['dt' => ['dt' => 'foo']]);
+
+        $r->addGroup('/g3', function(DummyRouteCollector $r) {
+            $r->get('/get', 'get', ['dt' => ['bar']]);
+        }, ['dt' => ['foo']]);
+
+        $expected = [
+            ['GET', '/g1/get', 'get', ['data' => 'g1']],
+            ['PUT', '/g1/put', 'put', ['data' => 'put']],
+            ['GET', '/g2/get', 'get', ['dt' => ['dt' => 'bar'], 'foo' => 'bar']],
+            ['PUT', '/g2/put', 'put', ['dt' => ['dt' => 'foo']]],
+            ['GET', '/g3/get', 'get', ['dt' => ['bar']]]
         ];
 
         $this->assertSame($expected, $r->routes);
@@ -92,6 +121,7 @@ class DummyRouteCollector extends RouteCollector {
     public function __construct() {}
     public function addRoute($method, $route, $handler, array $data = []) {
         $route = $this->currentGroupPrefix . $route;
-        $this->routes[] = [$method, $route, $handler];
+        $data = array_merge($this->currentGroupData, $data);
+        $this->routes[] = [$method, $route, $handler, $data];
     }
 }

--- a/test/RouteParser/StdTest.php
+++ b/test/RouteParser/StdTest.php
@@ -13,7 +13,7 @@ class StdTest extends \PhpUnit_Framework_TestCase {
     /** @dataProvider provideTestParseError */
     public function testParseError($routeString, $expectedExceptionMessage) {
         $parser = new Std();
-        $this->setExpectedException('FastRoute\\BadRouteException', $expectedExceptionMessage);
+        $this->setExpectedException('FastRoute\\Exception\\BadRouteException', $expectedExceptionMessage);
         $parser->parse($routeString);
     }
 


### PR DESCRIPTION
I was looking for a way to set extra information at route definition and retrieve it on dispatch but there is no easy way to do it.

Changing the dispatch return from an array to a object, should be a good start and, probably, turn new ideas more easy to implement. IMHO.

OK, In this Pull Request I change the dispatch return to an object and create a ability to set and get defined data to a specific route, updated tests and updated documentation.