### PR TITLE
running psalm, adding non-void docblocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,10 @@ matrix:
     - php: 7.0
 script:
   - ./vendor/bin/phpunit
+  - ./vendor/bin/psalm
   
 before_install:
   - travis_retry composer self-update
 
 install:
-  - composer install
+  - composer --prefer-source --ignore-platform-reqs install

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ matrix:
     - php: 7.0
 script:
   - ./vendor/bin/phpunit
+  - composer require --dev --update-with-dependencies --ignore-platform-reqs --prefer-source vimeo/psalm:dev-master
   - ./vendor/bin/psalm
-  
+
 before_install:
   - travis_retry composer self-update
 
 install:
-  - composer --prefer-source --ignore-platform-reqs install
+  - composer install

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,17 @@
       "email": "nikic@php.net"
     }
   ],
-  "require": {
-    "php": ">=5.4.0"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "~4.8|~5.7"
-},
   "autoload": {
     "psr-4": {
       "FastRoute\\": "src/"
     },
     "files": ["src/functions.php"]
+  },
+  "require": {
+    "php": ">=5.4.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "~4.8|~5.7",
+    "vimeo/psalm": "^0.3.36"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     "php": ">=5.4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.8|~5.7",
-    "vimeo/psalm": "^0.3.36"
+    "phpunit/phpunit": "~4.8|~5.7"
   }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<psalm
+    name="Example Psalm config with recommended defaults"
+    stopOnFirstError="false"
+    useDocblockTypes="true"
+    totallyTyped="false"
+>
+    <projectFiles>
+        <directory name="src" />
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+        <DeprecatedMethod errorLevel="info" />
+
+        <MissingClosureReturnType errorLevel="info" />
+        <MissingReturnType errorLevel="info" />
+        <MissingPropertyType errorLevel="info" />
+        <InvalidDocblock errorLevel="info" />
+        <MisplacedRequiredParam errorLevel="info" />
+
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <MissingConstructor errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -4,6 +4,7 @@
     stopOnFirstError="false"
     useDocblockTypes="true"
     totallyTyped="false"
+    requireVoidReturnType="false"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/DataGenerator/RegexBasedAbstract.php
+++ b/src/DataGenerator/RegexBasedAbstract.php
@@ -7,10 +7,24 @@ use FastRoute\BadRouteException;
 use FastRoute\Route;
 
 abstract class RegexBasedAbstract implements DataGenerator {
+    /**
+     * @var array
+     */
     protected $staticRoutes = [];
+
+    /**
+     * @var array
+     */
     protected $methodToRegexToRoutesMap = [];
 
+    /**
+     * @return int
+     */
     protected abstract function getApproxChunkSize();
+
+    /**
+     * @return mixed[]
+     */
     protected abstract function processChunk($regexToRoutesMap);
 
     public function addRoute($httpMethod, $routeData, $handler) {
@@ -21,6 +35,9 @@ abstract class RegexBasedAbstract implements DataGenerator {
         }
     }
 
+    /**
+     * @return mixed[]
+     */
     public function getData() {
         if (empty($this->methodToRegexToRoutesMap)) {
             return [$this->staticRoutes, []];
@@ -29,21 +46,31 @@ abstract class RegexBasedAbstract implements DataGenerator {
         return [$this->staticRoutes, $this->generateVariableRouteData()];
     }
 
+    /**
+     * @return mixed[]
+     */
     private function generateVariableRouteData() {
         $data = [];
         foreach ($this->methodToRegexToRoutesMap as $method => $regexToRoutesMap) {
             $chunkSize = $this->computeChunkSize(count($regexToRoutesMap));
+            $chunkSize = (int)$chunkSize;
             $chunks = array_chunk($regexToRoutesMap, $chunkSize, true);
             $data[$method] =  array_map([$this, 'processChunk'], $chunks);
         }
         return $data;
     }
 
+    /**
+     * @return float|int
+     */
     private function computeChunkSize($count) {
         $numParts = max(1, round($count / $this->getApproxChunkSize()));
         return ceil($count / $numParts);
     }
 
+    /**
+     * @return bool
+     */
     private function isStaticRoute($routeData) {
         return count($routeData) === 1 && is_string($routeData[0]);
     }
@@ -87,6 +114,9 @@ abstract class RegexBasedAbstract implements DataGenerator {
         );
     }
 
+    /**
+     * @return mixed[]
+     */
     private function buildRegexForRoute($routeData) {
         $regex = '';
         $variables = [];
@@ -118,6 +148,9 @@ abstract class RegexBasedAbstract implements DataGenerator {
         return [$regex, $variables];
     }
 
+    /**
+     * @return int|false
+     */
     private function regexHasCapturingGroups($regex) {
         if (false === strpos($regex, '(')) {
             // Needs to have at least a ( to contain a capturing group

--- a/src/Dispatcher/GroupPosBased.php
+++ b/src/Dispatcher/GroupPosBased.php
@@ -13,6 +13,9 @@ class GroupPosBased extends RegexBasedAbstract {
                 continue;
             }
 
+            // to resolve vimeo/psalm PossiblyUndefinedVariable
+            $i = 1;
+
             // find first non-empty match
             for ($i = 1; '' === $matches[$i]; ++$i);
 

--- a/src/Dispatcher/RegexBasedAbstract.php
+++ b/src/Dispatcher/RegexBasedAbstract.php
@@ -5,9 +5,19 @@ namespace FastRoute\Dispatcher;
 use FastRoute\Dispatcher;
 
 abstract class RegexBasedAbstract implements Dispatcher {
-    protected $staticRouteMap;
-    protected $variableRouteData;
+    /**
+     * @var array
+     */
+    protected $staticRouteMap = [];
 
+    /**
+     * @var array
+     */
+    protected $variableRouteData = [];
+
+    /**
+     * @return mixed[]
+     */
     protected abstract function dispatchVariableRoute($routeData, $uri);
 
     public function dispatch($httpMethod, $uri) {

--- a/src/Route.php
+++ b/src/Route.php
@@ -3,9 +3,24 @@
 namespace FastRoute;
 
 class Route {
+    /**
+     * @var string
+     */
     public $httpMethod;
+
+    /**
+     * @var string
+     */
     public $regex;
+
+    /**
+     * @var array
+     */
     public $variables;
+
+    /**
+     * @var mixed
+     */
     public $handler;
 
     /**

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -3,8 +3,19 @@
 namespace FastRoute;
 
 class RouteCollector {
+    /**
+     * @var RouteParser
+     */
     protected $routeParser;
+
+    /**
+     * @var DataGenerator
+     */
     protected $dataGenerator;
+
+    /**
+     * @var string
+     */
     protected $currentGroupPrefix;
 
     /**

--- a/src/RouteParser.php
+++ b/src/RouteParser.php
@@ -29,8 +29,8 @@ interface RouteParser {
      * Here one route string was converted into two route data arrays.
      *
      * @param string $route Route string to parse
-     * 
-     * @return mixed[][] Array of route data arrays
+     *
+     * @return (mixed[])[] Array of route data arrays
      */
     public function parse($route);
 }

--- a/src/RouteParser.php
+++ b/src/RouteParser.php
@@ -30,7 +30,7 @@ interface RouteParser {
      *
      * @param string $route Route string to parse
      *
-     * @return (mixed[])[] Array of route data arrays
+     * @return mixed[][] Array of route data arrays
      */
     public function parse($route);
 }

--- a/src/RouteParser/Std.php
+++ b/src/RouteParser/Std.php
@@ -21,9 +21,6 @@ class Std implements RouteParser {
 REGEX;
     const DEFAULT_DISPATCH_REGEX = '[^/]+';
 
-    /**
-     * @return mixed[][]
-     */
     public function parse($route) {
         $routeWithoutClosingOptionals = rtrim($route, ']');
         $numOptionals = strlen($route) - strlen($routeWithoutClosingOptionals);
@@ -40,9 +37,6 @@ REGEX;
 
         $currentRoute = '';
 
-        /**
-         * @var array[] $routeDatas
-         */
         $routeDatas = [];
         foreach ($segments as $n => $segment) {
             if ($segment === '' && $n !== 0) {

--- a/src/RouteParser/Std.php
+++ b/src/RouteParser/Std.php
@@ -21,6 +21,9 @@ class Std implements RouteParser {
 REGEX;
     const DEFAULT_DISPATCH_REGEX = '[^/]+';
 
+    /**
+     * @return mixed[][]
+     */
     public function parse($route) {
         $routeWithoutClosingOptionals = rtrim($route, ']');
         $numOptionals = strlen($route) - strlen($routeWithoutClosingOptionals);
@@ -36,6 +39,10 @@ REGEX;
         }
 
         $currentRoute = '';
+
+        /**
+         * @var array[] $routeDatas
+         */
         $routeDatas = [];
         foreach ($segments as $n => $segment) {
             if ($segment === '' && $n !== 0) {
@@ -50,6 +57,7 @@ REGEX;
 
     /**
      * Parses a route string that does not contain optional segments.
+     * @return mixed[]
      */
     private function parsePlaceholders($route) {
         if (!preg_match_all(


### PR DESCRIPTION
Was running static analysis on a project, FastRoute came up in the output- I ran `./vendor/bin/psalm` with the default config & fixed all the void return type notices, as those are rather php7-specific.