### PR TITLE
Added namespaced TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     "php": ">=5.4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.8|~5.7"
+    "phpunit/phpunit": "^4.8.35|~5.7"
   }
 }

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -3,8 +3,9 @@
 namespace FastRoute\Dispatcher;
 
 use FastRoute\RouteCollector;
+use PHPUnit\Framework\TestCase;
 
-abstract class DispatcherTest extends \PHPUnit_Framework_TestCase {
+abstract class DispatcherTest extends TestCase {
 
     /**
      * Delegate dispatcher selection to child test classes

--- a/test/HackTypechecker/HackTypecheckerTest.php
+++ b/test/HackTypechecker/HackTypecheckerTest.php
@@ -2,7 +2,9 @@
 
 namespace FastRoute;
 
-class HackTypecheckerTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class HackTypecheckerTest extends TestCase {
     const SERVER_ALREADY_RUNNING_CODE = 77;
     public function testTypechecks($recurse = true) {
         if (!defined('HHVM_VERSION')) {

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -2,7 +2,9 @@
 
 namespace FastRoute;
 
-class RouteCollectorTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class RouteCollectorTest extends TestCase {
     public function testShortcuts() {
         $r = new DummyRouteCollector();
 

--- a/test/RouteParser/StdTest.php
+++ b/test/RouteParser/StdTest.php
@@ -2,7 +2,9 @@
 
 namespace FastRoute\RouteParser;
 
-class StdTest extends \PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class StdTest extends TestCase {
     /** @dataProvider provideTestParse */
     public function testParse($routeString, $expectedRouteDatas) {
         $parser = new Std();


### PR DESCRIPTION
This PR resolves:
* tests now extend from `PHPUnit\Framework\TestCase` rather than `PHPUnit_Framework_TestCase`