### PR TITLE
Explicitly define nullables in shapes (non-optional anymore)

### DIFF
--- a/FastRoute.hhi
+++ b/FastRoute.hhi
@@ -34,34 +34,22 @@ namespace FastRoute {
     function simpleDispatcher(
         (function(RouteCollector): void) $routeDefinitionCallback,
         shape(
-          'routeParser' => ?classname<RouteParser>,
-          'dataGenerator' => ?classname<DataGenerator>,
-          'dispatcher' => ?classname<Dispatcher>,
-          'routeCollector' => ?classname<RouteCollector>,
-        ) $options = shape(
-          'routeParser' => \FastRoute\RouteParser\Std::class,
-          'dataGenerator' => \FastRoute\DataGenerator\GroupCountBased::class,
-          'dispatcher' => \FastRoute\Dispatcher\GroupCountBased::class,
-          'routeCollector' => \FastRoute\RouteCollector::class
-        )): Dispatcher;
+          ?'routeParser' => classname<RouteParser>,
+          ?'dataGenerator' => classname<DataGenerator>,
+          ?'dispatcher' => classname<Dispatcher>,
+          ?'routeCollector' => classname<RouteCollector>,
+        ) $options = shape()): Dispatcher;
 
     function cachedDispatcher(
         (function(RouteCollector): void) $routeDefinitionCallback,
         shape(
-          'routeParser' => ?classname<RouteParser>,
-          'dataGenerator' => ?classname<DataGenerator>,
-          'dispatcher' => ?classname<Dispatcher>,
-          'routeCollector' => ?classname<RouteCollector>,
-          'cacheDisabled' => ?bool,
-          'cacheFile' => ?string,
-        ) $options = shape(
-          'routeParser' => \FastRoute\RouteParser\Std::class,
-          'dataGenerator' => \FastRoute\DataGenerator\GroupCountBased::class,
-          'dispatcher' => \FastRoute\Dispatcher\GroupCountBased::class,
-          'routeCollector' => \FastRoute\RouteCollector::class,
-          'cacheDisabled' => false,
-          'cacheFile' => null
-        )): Dispatcher;
+          ?'routeParser' => classname<RouteParser>,
+          ?'dataGenerator' => classname<DataGenerator>,
+          ?'dispatcher' => classname<Dispatcher>,
+          ?'routeCollector' => classname<RouteCollector>,
+          ?'cacheDisabled' => bool,
+          ?'cacheFile' => string,
+        ) $options = shape()): Dispatcher;
 }
 
 namespace FastRoute\DataGenerator {

--- a/FastRoute.hhi
+++ b/FastRoute.hhi
@@ -37,7 +37,7 @@ namespace FastRoute {
           ?'routeParser' => classname<RouteParser>,
           ?'dataGenerator' => classname<DataGenerator>,
           ?'dispatcher' => classname<Dispatcher>,
-          ?'routeCollector' => classname<RouteCollector>,
+          ?'routeCollector' => classname<RouteCollector>
         ) $options = shape()): Dispatcher;
 
     function cachedDispatcher(
@@ -48,7 +48,7 @@ namespace FastRoute {
           ?'dispatcher' => classname<Dispatcher>,
           ?'routeCollector' => classname<RouteCollector>,
           ?'cacheDisabled' => bool,
-          ?'cacheFile' => string,
+          ?'cacheFile' => string
         ) $options = shape()): Dispatcher;
 }
 

--- a/FastRoute.hhi
+++ b/FastRoute.hhi
@@ -38,7 +38,12 @@ namespace FastRoute {
           'dataGenerator' => ?classname<DataGenerator>,
           'dispatcher' => ?classname<Dispatcher>,
           'routeCollector' => ?classname<RouteCollector>,
-        ) $options = shape()): Dispatcher;
+        ) $options = shape(
+          'routeParser' => \FastRoute\RouteParser\Std::class,
+          'dataGenerator' => \FastRoute\DataGenerator\GroupCountBased::class,
+          'dispatcher' => \FastRoute\Dispatcher\GroupCountBased::class,
+          'routeCollector' => \FastRoute\RouteCollector::class
+        )): Dispatcher;
 
     function cachedDispatcher(
         (function(RouteCollector): void) $routeDefinitionCallback,
@@ -49,7 +54,14 @@ namespace FastRoute {
           'routeCollector' => ?classname<RouteCollector>,
           'cacheDisabled' => ?bool,
           'cacheFile' => ?string,
-        ) $options = shape()): Dispatcher;
+        ) $options = shape(
+          'routeParser' => \FastRoute\RouteParser\Std::class,
+          'dataGenerator' => \FastRoute\DataGenerator\GroupCountBased::class,
+          'dispatcher' => \FastRoute\Dispatcher\GroupCountBased::class,
+          'routeCollector' => \FastRoute\RouteCollector::class,
+          'cacheDisabled' => false,
+          'cacheFile' => null
+        )): Dispatcher;
 }
 
 namespace FastRoute\DataGenerator {

--- a/src/functions.php
+++ b/src/functions.php
@@ -41,7 +41,7 @@ if (!function_exists('FastRoute\simpleDispatcher')) {
             'cacheDisabled' => false,
         ];
 
-        if (!isset($options['cacheFile'])) {
+        if (!isset($options['cacheFile']) || $options['cacheFile'] === null) {
             throw new \LogicException('Must specify "cacheFile" option');
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -41,7 +41,7 @@ if (!function_exists('FastRoute\simpleDispatcher')) {
             'cacheDisabled' => false,
         ];
 
-        if (!isset($options['cacheFile']) || $options['cacheFile'] === null) {
+        if (!isset($options['cacheFile'])) {
             throw new \LogicException('Must specify "cacheFile" option');
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -11,10 +11,10 @@ if (!function_exists('FastRoute\simpleDispatcher')) {
      */
     function simpleDispatcher(callable $routeDefinitionCallback, array $options = []) {
         $options += [
-            'routeParser' => 'FastRoute\\RouteParser\\Std',
-            'dataGenerator' => 'FastRoute\\DataGenerator\\GroupCountBased',
-            'dispatcher' => 'FastRoute\\Dispatcher\\GroupCountBased',
-            'routeCollector' => 'FastRoute\\RouteCollector',
+            'routeParser' => '\\FastRoute\\RouteParser\\Std',
+            'dataGenerator' => '\\FastRoute\\DataGenerator\\GroupCountBased',
+            'dispatcher' => '\\FastRoute\\Dispatcher\\GroupCountBased',
+            'routeCollector' => '\\FastRoute\\RouteCollector',
         ];
 
         /** @var RouteCollector $routeCollector */
@@ -34,10 +34,10 @@ if (!function_exists('FastRoute\simpleDispatcher')) {
      */
     function cachedDispatcher(callable $routeDefinitionCallback, array $options = []) {
         $options += [
-            'routeParser' => 'FastRoute\\RouteParser\\Std',
-            'dataGenerator' => 'FastRoute\\DataGenerator\\GroupCountBased',
-            'dispatcher' => 'FastRoute\\Dispatcher\\GroupCountBased',
-            'routeCollector' => 'FastRoute\\RouteCollector',
+            'routeParser' => '\\FastRoute\\RouteParser\\Std',
+            'dataGenerator' => '\\FastRoute\\DataGenerator\\GroupCountBased',
+            'dispatcher' => '\\FastRoute\\Dispatcher\\GroupCountBased',
+            'routeCollector' => '\\FastRoute\\RouteCollector',
             'cacheDisabled' => false,
         ];
 

--- a/test/HackTypechecker/fixtures/empty_options.php
+++ b/test/HackTypechecker/fixtures/empty_options.php
@@ -3,9 +3,17 @@
 namespace FastRoute\TestFixtures;
 
 function empty_options_simple(): \FastRoute\Dispatcher {
-    return \FastRoute\simpleDispatcher($collector ==> {}, shape());
+    if(version_compare(HHVM_VERSION, "3.23") < 0){
+        // UNSAFE
+        return \FastRoute\simpleDispatcher($collector ==> {}, shape());
+    }
+    return no_options_simple();
 }
 
 function empty_options_cached(): \FastRoute\Dispatcher {
-    return \FastRoute\cachedDispatcher($collector ==> {}, shape());
+    if(version_compare(HHVM_VERSION, "3.23") < 0){
+        // UNSAFE
+        return \FastRoute\cachedDispatcher($collector ==> {}, shape());
+    }
+    return no_options_cached();
 }

--- a/test/HackTypechecker/fixtures/empty_options.php
+++ b/test/HackTypechecker/fixtures/empty_options.php
@@ -3,7 +3,7 @@
 namespace FastRoute\TestFixtures;
 
 function empty_options_simple(): \FastRoute\Dispatcher {
-    if(version_compare(HHVM_VERSION, "3.23") < 0){
+    if(version_compare(HHVM_VERSION, '3.23', '<')){
         // UNSAFE
         return \FastRoute\simpleDispatcher($collector ==> {}, shape());
     }
@@ -11,7 +11,7 @@ function empty_options_simple(): \FastRoute\Dispatcher {
 }
 
 function empty_options_cached(): \FastRoute\Dispatcher {
-    if(version_compare(HHVM_VERSION, "3.23") < 0){
+    if(version_compare(HHVM_VERSION, '3.23', '<')){
         // UNSAFE
         return \FastRoute\cachedDispatcher($collector ==> {}, shape());
     }

--- a/test/HackTypechecker/fixtures/empty_options.php
+++ b/test/HackTypechecker/fixtures/empty_options.php
@@ -3,7 +3,7 @@
 namespace FastRoute\TestFixtures;
 
 function empty_options_simple(): \FastRoute\Dispatcher {
-    if(version_compare(HHVM_VERSION, '3.23', '<')){
+    if(version_compare($GLOBALS['HHVM_VERSION'], '3.23', '<')){
         // UNSAFE
         return \FastRoute\simpleDispatcher($collector ==> {}, shape());
     }
@@ -11,7 +11,7 @@ function empty_options_simple(): \FastRoute\Dispatcher {
 }
 
 function empty_options_cached(): \FastRoute\Dispatcher {
-    if(version_compare(HHVM_VERSION, '3.23', '<')){
+    if(version_compare($GLOBALS['HHVM_VERSION'], '3.23', '<')){
         // UNSAFE
         return \FastRoute\cachedDispatcher($collector ==> {}, shape());
     }


### PR DESCRIPTION
As stated on the [introduction to hack-shapes](https://docs.hhvm.com/hack/shapes/introduction) _"Since HHVM 3.23, nullable fields are no longer considered optional"_
That leads to typechecker-errors:
```
› hh_client check
FastRoute.hhi:41:11,18: Wrong type hint (Typing[4057])
  FastRoute.hhi:41:22,26: The field 'dataGenerator' is missing
  FastRoute.hhi:36:9,13: The field 'dataGenerator' is defined
FastRoute.hhi:52:11,18: Wrong type hint (Typing[4057])
  FastRoute.hhi:52:22,26: The field 'cacheDisabled' is missing
  FastRoute.hhi:45:9,13: The field 'cacheDisabled' is defined
test/HackTypechecker/fixtures/empty_options.php:6:59,63: Invalid argument (Typing[4057])
  test/HackTypechecker/fixtures/empty_options.php:6:59,63: The field 'dataGenerator' is missing
  FastRoute.hhi:36:9,13: The field 'dataGenerator' is defined
test/HackTypechecker/fixtures/empty_options.php:10:59,63: Invalid argument (Typing[4057])
  test/HackTypechecker/fixtures/empty_options.php:10:59,63: The field 'cacheDisabled' is missing
  FastRoute.hhi:45:9,13: The field 'cacheDisabled' is defined
```

The errors are resolved and the HackTypechecker-fixtures are adjust to return `no_options_*` instead of `empty_options_*` if the hhvm-version is 3.23 or newer.