### PR TITLE
Group Handler Modifier

### DIFF
--- a/src/RouteCollectorModifier.php
+++ b/src/RouteCollectorModifier.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace FastRoute;
+
+class RouteCollectorModifier extends \FastRoute\RouteCollector
+{
+    /** @var array */
+    private $currentModifiers = [];
+
+    /**
+     * Adds a route to the collection.
+     *
+     * The handler will be run through the current modifiers before being assigned to a route.
+     * The syntax used in the $route string depends on the used route parser.
+     *
+     * @param string|string[] $httpMethod
+     * @param string $route
+     * @param mixed $handler
+     */
+    public function addRoute($httpMethod, $route, $handler)
+    {
+        $modifiedHandler = $handler;
+
+        foreach($this->currentModifiers as $modifier) {
+            $modifiedHandler = $modifier($modifiedHandler);
+        }
+
+        parent::addroute($httpMethod, $route, $modifiedHandler);
+    }
+
+    /**
+     * Create a route group with a common prefix and optional handler modifiers.
+     *
+     * All routes created in the passed callback will have the given group prefix prepended
+     * and will also have had all modifiers run against their handlers.
+     *
+     * @param string $prefix
+     * @param callable $callback
+     * @param callable $modifier
+     */
+    public function addGroup($prefix, callable $callback, callable $modifier = null)
+    {
+        $previousModifiers = $this->currentModifiers;
+        $this->currentModifiers = array_merge($previousModifiers, (array)$modifier);
+        parent::addGroup($prefix, $callback);
+        $this->currentModifiers = $previousModifiers;
+    }
+}


### PR DESCRIPTION
## Group Handler Modifier

This is not ready to be integrated, changes would need to be made to integrate this properly, but before I spend more time on this, I'd like some opinions :)

FastRoute does one thing and it does it well; I don't anything should dilute this. I wanted a way to add middleware to routes and (more specifically) groups of routes. There are numerous ways that you could implement something like middleware with FastRoute, but I kept coming back to the idea that it would be nice if FastRoute provided a simple way to mutate route handlers on a group basis.

I don't think the core functionality of FastRoute should be diluted at all, so I've tried to keep this as generic as possible, there's nothing specific to middleware here, but this change would allow users to implement something like middleware quite nicely.

My changes follow the same pattern that's been used to implement the group prefixes.
Instead of changing the core `RouteCollector` class, I've extended from it to give users the choice by using the `$options` argument for the `simpleDispatcher` or the `cachedDispatcher`:

```php
'routeCollector' => 'FastRoute\\RouteCollectorModifier'
```

## Examples

I've not run these examples, so there may be errors that I've missed, however, it should be enough to demonstrate my point.

### With `RouteCollector`

This will work, but it doesn't scale very well if you need multiple levels of 'wrappers' that need applying on different groups. There are, of course, other ways to implement this, such as creating a class to wrap the handlers and create a 'stack' of wrappers, but I don't believe this is the optimal way to achieve the desired outcome.

```php
$route_collector->addGroup('/api', function($route_collector) {
    $log = function($handler) {
        return function($request) use ($handler) {
            // Do something before the handler (like logging)
            $handler($request);
            // Do something after the handler (like logging)
        };
    };

    $route_collector->get('/list-users', $log('get_all_users'));
    $route_collector->get('/list-products', $log('get_all_products'));
    // ....
});
```

### With `RouteCollectorModifier`

```php
$log = function($handler) {
    return function($request) use ($handler) {
        // Do something before the handler (like logging)
        $handler($request);
        // Do something after the handler (like logging)
    };
};

$route_collector->addGroup('/api', function($route_collector) {
    $route_collector->get('/list-users', 'get_all_users');
    $route_collector->get('/list-products', 'get_all_products');
    // ....
}, $log);
```

I think this scales better (imagine nested groups and multiple handlers per group) while being flexible and generalised enough that it doesn't tie itself to one use case.

## Final Thoughts

I'm looking for opinions on whether this is a good fit for FastRoute, I can see reasons to include it and reasons not to, so I'm definitely keen to talk it through!

There's still work to do, but the core class (not necessarily complete) is included for review.

Thanks for reading :)