### PR TITLE
Add first-class OPTIONS support

### DIFF
--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -141,6 +141,19 @@ class RouteCollector
     }
 
     /**
+     * Adds an OPTIONS route to the collection
+     *
+     * This is simply an alias of $this->addRoute('OPTIONS', $route, $handler)
+     *
+     * @param string $route
+     * @param mixed  $handler
+     */
+    public function options($route, $handler)
+    {
+        $this->addRoute('OPTIONS', $route, $handler);
+    }
+
+    /**
      * Returns the collected route data, as provided by the data generator.
      *
      * @return array

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -413,6 +413,14 @@ abstract class DispatcherTest extends TestCase
 
         $cases[] = ['POST', '/bar', $callback, 'handler1', ['foo' => 'bar']];
 
+        // 27 ----
+
+        $callback = function(RouteCollector $r) {
+            $r->addRoute('OPTIONS', '/about', 'handler0');
+        };
+
+        $cases[] = ['OPTIONS', '/about', $callback, 'handler0', []];
+
         // x -------------------------------------------------------------------------------------->
 
         return $cases;

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -16,6 +16,7 @@ class RouteCollectorTest extends TestCase
         $r->patch('/patch', 'patch');
         $r->post('/post', 'post');
         $r->put('/put', 'put');
+        $r->options('/options', 'options');
 
         $expected = [
             ['DELETE', '/delete', 'delete'],
@@ -24,6 +25,7 @@ class RouteCollectorTest extends TestCase
             ['PATCH', '/patch', 'patch'],
             ['POST', '/post', 'post'],
             ['PUT', '/put', 'put'],
+            ['OPTIONS', '/options', 'options'],
         ];
 
         $this->assertSame($expected, $r->routes);
@@ -39,6 +41,7 @@ class RouteCollectorTest extends TestCase
         $r->patch('/patch', 'patch');
         $r->post('/post', 'post');
         $r->put('/put', 'put');
+        $r->options('/options', 'options');
 
         $r->addGroup('/group-one', function (DummyRouteCollector $r) {
             $r->delete('/delete', 'delete');
@@ -47,6 +50,7 @@ class RouteCollectorTest extends TestCase
             $r->patch('/patch', 'patch');
             $r->post('/post', 'post');
             $r->put('/put', 'put');
+            $r->options('/options', 'options');
 
             $r->addGroup('/group-two', function (DummyRouteCollector $r) {
                 $r->delete('/delete', 'delete');
@@ -55,6 +59,7 @@ class RouteCollectorTest extends TestCase
                 $r->patch('/patch', 'patch');
                 $r->post('/post', 'post');
                 $r->put('/put', 'put');
+                $r->options('/options', 'options');
             });
         });
 
@@ -72,18 +77,21 @@ class RouteCollectorTest extends TestCase
             ['PATCH', '/patch', 'patch'],
             ['POST', '/post', 'post'],
             ['PUT', '/put', 'put'],
+            ['OPTIONS', '/options', 'options'],
             ['DELETE', '/group-one/delete', 'delete'],
             ['GET', '/group-one/get', 'get'],
             ['HEAD', '/group-one/head', 'head'],
             ['PATCH', '/group-one/patch', 'patch'],
             ['POST', '/group-one/post', 'post'],
             ['PUT', '/group-one/put', 'put'],
+            ['OPTIONS', '/group-one/options', 'options'],
             ['DELETE', '/group-one/group-two/delete', 'delete'],
             ['GET', '/group-one/group-two/get', 'get'],
             ['HEAD', '/group-one/group-two/head', 'head'],
             ['PATCH', '/group-one/group-two/patch', 'patch'],
             ['POST', '/group-one/group-two/post', 'post'],
             ['PUT', '/group-one/group-two/put', 'put'],
+            ['OPTIONS', '/group-one/group-two/options', 'options'],
             ['GET', '/admin-some-info', 'admin-some-info'],
             ['GET', '/admin-more-info', 'admin-more-info'],
         ];


### PR DESCRIPTION
This adds a convenience method for HTTP OPTIONS routes (which come up a fair bit when dealing with CORS), as well as some additional test coverage asserting that they are routed correctly.