### PR TITLE
Add support for optional middle segments

### DIFF
--- a/test/RouteParser/StdTest.php
+++ b/test/RouteParser/StdTest.php
@@ -115,6 +115,46 @@ class StdTest extends TestCase
                     ['/', ['_foo', '.*']]
                 ]
             ],
+            [
+                '/test[/opt]/required',
+                [
+                    ['/test/required'],
+                    ['/test/opt/required'],
+                ]
+            ],
+            [
+                '/test[/opt[/sub1][/sub2]]/required[/end]',
+                [
+                    ['/test/required'],
+                    ['/test/opt/required'],
+                    ['/test/opt/sub1/required'],
+                    ['/test/opt/sub2/required'],
+                    ['/test/opt/sub1/sub2/required'],
+                    ['/test/required/end'],
+                    ['/test/opt/required/end'],
+                    ['/test/opt/sub1/required/end'],
+                    ['/test/opt/sub2/required/end'],
+                    ['/test/opt/sub1/sub2/required/end'],
+                ]
+            ],
+            [
+                '/test[/[opt[/]]]',
+                [
+                    ['/test'],
+                    ['/test/'],
+                    ['/test/opt'],
+                    ['/test/opt/'],
+                ]
+            ],
+            [
+                '/test[/opt][/]',
+                [
+                    ['/test'],
+                    ['/test/opt'],
+                    ['/test/'],
+                    ['/test/opt/'],
+                ]
+            ]
         ];
     }
 
@@ -134,6 +174,10 @@ class StdTest extends TestCase
                 "Number of opening '[' and closing ']' does not match"
             ],
             [
+                '/test]opt',
+                "Number of opening '[' and closing ']' does not match"
+            ],
+            [
                 '/test[]',
                 'Empty optional part'
             ],
@@ -144,10 +188,6 @@ class StdTest extends TestCase
             [
                 '[[test]]',
                 'Empty optional part'
-            ],
-            [
-                '/test[/opt]/required',
-                'Optional segments can only occur at the end of a route'
             ],
         ];
     }


### PR DESCRIPTION
Looking at the source, I thought the limitation of allowing optional parts only in the end of the route definition was rather arbitrary and made some route definitions much more complex than they needed to be.

This PR rewrites the parsing logic for optional parts in order to allow optional parts in the middle of routes, instead of just allowing them in the end.

I tried to maintain as high compatibility with the existing parsing logic failures as possible to avoid unnecessary backwards compatibility breaks while allowing new behavior.