### PR TITLE
Add RouteCollector::any()

### DIFF
--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -49,6 +49,12 @@ class RouteCollector
         $this->currentGroupPrefix = $previousGroupPrefix;
     }
 
+    /** @param mixed $handler */
+    public function any(string $route, $handler): void
+    {
+        $this->addRoute('*', $route, $handler);
+    }
+
     /**
      * Adds a GET route to the collection
      *

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -11,6 +11,7 @@ class RouteCollectorTest extends TestCase
     {
         $r = new DummyRouteCollector();
 
+        $r->any('/any', 'any');
         $r->delete('/delete', 'delete');
         $r->get('/get', 'get');
         $r->head('/head', 'head');
@@ -20,6 +21,7 @@ class RouteCollectorTest extends TestCase
         $r->options('/options', 'options');
 
         $expected = [
+            ['*', '/any', 'any'],
             ['DELETE', '/delete', 'delete'],
             ['GET', '/get', 'get'],
             ['HEAD', '/head', 'head'],


### PR DESCRIPTION
This PR adds an `any()` method to `RouteCollector` as a shortcut for routes without a specific http method.

(also, why did i commit the whitespace changes??? that was not intended!)