### PR TITLE
Improve resource usage

### DIFF
--- a/src/DataGenerator.php
+++ b/src/DataGenerator.php
@@ -22,7 +22,7 @@ interface DataGenerator
      * Returns dispatcher data in some unspecified format, which
      * depends on the used method of dispatch.
      *
-     * @return mixed[]
+     * @return array{0: array<string, array<string, mixed>>, 1: array<string, array<array{regex: string, suffix?: string, routeMap: array<int|string, array{0: mixed, 1: array<string, string>}>}>>}
      */
     public function getData(): array;
 }

--- a/src/DataGenerator/CharCountBased.php
+++ b/src/DataGenerator/CharCountBased.php
@@ -13,9 +13,7 @@ class CharCountBased extends RegexBasedAbstract
         return 30;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     protected function processChunk(array $regexToRoutesMap): array
     {
         $routeMap = [];

--- a/src/DataGenerator/GroupCountBased.php
+++ b/src/DataGenerator/GroupCountBased.php
@@ -15,9 +15,7 @@ class GroupCountBased extends RegexBasedAbstract
         return 10;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     protected function processChunk(array $regexToRoutesMap): array
     {
         $routeMap = [];

--- a/src/DataGenerator/GroupPosBased.php
+++ b/src/DataGenerator/GroupPosBased.php
@@ -13,9 +13,7 @@ class GroupPosBased extends RegexBasedAbstract
         return 10;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     protected function processChunk(array $regexToRoutesMap): array
     {
         $routeMap = [];

--- a/src/DataGenerator/MarkBased.php
+++ b/src/DataGenerator/MarkBased.php
@@ -12,9 +12,7 @@ class MarkBased extends RegexBasedAbstract
         return 30;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     protected function processChunk(array $regexToRoutesMap): array
     {
         $routeMap = [];

--- a/src/DataGenerator/RegexBasedAbstract.php
+++ b/src/DataGenerator/RegexBasedAbstract.php
@@ -22,10 +22,10 @@ use function strpos;
 // phpcs:ignore SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousSuffix
 abstract class RegexBasedAbstract implements DataGenerator
 {
-    /** @var mixed[][] */
+    /** @var array<string, array<string, mixed>> */
     protected array $staticRoutes = [];
 
-    /** @var Route[][] */
+    /** @var array<string, array<string, Route>> */
     protected array $methodToRegexToRoutesMap = [];
 
     abstract protected function getApproxChunkSize(): int;
@@ -33,13 +33,11 @@ abstract class RegexBasedAbstract implements DataGenerator
     /**
      * @param array<string, Route> $regexToRoutesMap
      *
-     * @return mixed[]
+     * @return array{regex: string, suffix?: string, routeMap: array<int|string, array{0: mixed, 1: array<string, string>}>}
      */
     abstract protected function processChunk(array $regexToRoutesMap): array;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     public function addRoute(string $httpMethod, array $routeData, $handler): void
     {
         if ($this->isStaticRoute($routeData)) {
@@ -49,9 +47,7 @@ abstract class RegexBasedAbstract implements DataGenerator
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     public function getData(): array
     {
         if ($this->methodToRegexToRoutesMap === []) {
@@ -61,7 +57,7 @@ abstract class RegexBasedAbstract implements DataGenerator
         return [$this->staticRoutes, $this->generateVariableRouteData()];
     }
 
-    /** @return mixed[] */
+    /** @return array<string, array<array{regex: string, suffix?: string, routeMap: array<int|string, array{0: mixed, 1: array<string, string>}>}>> */
     private function generateVariableRouteData(): array
     {
         $data = [];
@@ -146,7 +142,7 @@ abstract class RegexBasedAbstract implements DataGenerator
     /**
      * @param mixed[] $routeData
      *
-     * @return mixed[]
+     * @return array{0: string, 1: array<string, string>}
      */
     private function buildRegexForRoute(array $routeData): array
     {

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -18,7 +18,7 @@ interface Dispatcher
      *     [self::METHOD_NOT_ALLOWED, ['GET', 'OTHER_ALLOWED_METHODS']]
      *     [self::FOUND, $handler, ['varName' => 'value', ...]]
      *
-     * @return array<int, mixed>
+     * @return array{0: int, 1?: list<string>|mixed, 2?: array<string, string>}
      */
     public function dispatch(string $httpMethod, string $uri): array;
 }

--- a/src/Dispatcher/CharCountBased.php
+++ b/src/Dispatcher/CharCountBased.php
@@ -8,9 +8,7 @@ use function preg_match;
 
 class CharCountBased extends RegexBasedAbstract
 {
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     protected function dispatchVariableRoute(array $routeData, string $uri): ?array
     {
         foreach ($routeData as $data) {

--- a/src/Dispatcher/CharCountBased.php
+++ b/src/Dispatcher/CharCountBased.php
@@ -11,7 +11,7 @@ class CharCountBased extends RegexBasedAbstract
     /**
      * {@inheritDoc}
      */
-    protected function dispatchVariableRoute(array $routeData, string $uri): array
+    protected function dispatchVariableRoute(array $routeData, string $uri): ?array
     {
         foreach ($routeData as $data) {
             if (! preg_match($data['regex'], $uri . $data['suffix'], $matches)) {
@@ -29,6 +29,6 @@ class CharCountBased extends RegexBasedAbstract
             return [self::FOUND, $handler, $vars];
         }
 
-        return [self::NOT_FOUND];
+        return null;
     }
 }

--- a/src/Dispatcher/GroupCountBased.php
+++ b/src/Dispatcher/GroupCountBased.php
@@ -11,7 +11,7 @@ class GroupCountBased extends RegexBasedAbstract
     /**
      * {@inheritDoc}
      */
-    protected function dispatchVariableRoute(array $routeData, string $uri): array
+    protected function dispatchVariableRoute(array $routeData, string $uri): ?array
     {
         foreach ($routeData as $data) {
             if (! preg_match($data['regex'], $uri, $matches)) {
@@ -29,6 +29,6 @@ class GroupCountBased extends RegexBasedAbstract
             return [self::FOUND, $handler, $vars];
         }
 
-        return [self::NOT_FOUND];
+        return null;
     }
 }

--- a/src/Dispatcher/GroupCountBased.php
+++ b/src/Dispatcher/GroupCountBased.php
@@ -8,9 +8,7 @@ use function preg_match;
 
 class GroupCountBased extends RegexBasedAbstract
 {
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     protected function dispatchVariableRoute(array $routeData, string $uri): ?array
     {
         foreach ($routeData as $data) {

--- a/src/Dispatcher/GroupPosBased.php
+++ b/src/Dispatcher/GroupPosBased.php
@@ -7,9 +7,7 @@ use function preg_match;
 
 class GroupPosBased extends RegexBasedAbstract
 {
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     protected function dispatchVariableRoute(array $routeData, string $uri): ?array
     {
         foreach ($routeData as $data) {

--- a/src/Dispatcher/GroupPosBased.php
+++ b/src/Dispatcher/GroupPosBased.php
@@ -10,7 +10,7 @@ class GroupPosBased extends RegexBasedAbstract
     /**
      * {@inheritDoc}
      */
-    protected function dispatchVariableRoute(array $routeData, string $uri): array
+    protected function dispatchVariableRoute(array $routeData, string $uri): ?array
     {
         foreach ($routeData as $data) {
             if (! preg_match($data['regex'], $uri, $matches)) {
@@ -32,6 +32,6 @@ class GroupPosBased extends RegexBasedAbstract
             return [self::FOUND, $handler, $vars];
         }
 
-        return [self::NOT_FOUND];
+        return null;
     }
 }

--- a/src/Dispatcher/MarkBased.php
+++ b/src/Dispatcher/MarkBased.php
@@ -10,7 +10,7 @@ class MarkBased extends RegexBasedAbstract
     /**
      * {@inheritDoc}
      */
-    protected function dispatchVariableRoute(array $routeData, string $uri): array
+    protected function dispatchVariableRoute(array $routeData, string $uri): ?array
     {
         foreach ($routeData as $data) {
             if (! preg_match($data['regex'], $uri, $matches)) {
@@ -28,6 +28,6 @@ class MarkBased extends RegexBasedAbstract
             return [self::FOUND, $handler, $vars];
         }
 
-        return [self::NOT_FOUND];
+        return null;
     }
 }

--- a/src/Dispatcher/MarkBased.php
+++ b/src/Dispatcher/MarkBased.php
@@ -7,9 +7,7 @@ use function preg_match;
 
 class MarkBased extends RegexBasedAbstract
 {
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     protected function dispatchVariableRoute(array $routeData, string $uri): ?array
     {
         foreach ($routeData as $data) {

--- a/src/Dispatcher/RegexBasedAbstract.php
+++ b/src/Dispatcher/RegexBasedAbstract.php
@@ -8,13 +8,13 @@ use FastRoute\Dispatcher;
 // phpcs:ignore SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousSuffix
 abstract class RegexBasedAbstract implements Dispatcher
 {
-    /** @var mixed[][] */
+    /** @var array<string, array<string, mixed>> */
     protected array $staticRouteMap = [];
 
-    /** @var mixed[] */
+    /** @var array<string, array<array{regex: string, suffix?: string, routeMap: array<int|string, array{0: mixed, 1: array<string, string>}>}>> */
     protected array $variableRouteData = [];
 
-    /** @param mixed[] $data */
+    /** @param array{0: array<string, array<string, mixed>>, 1: array<string, array<array{regex: string, suffix?: string, routeMap: array<int|string, array{0: mixed, 1: array<string, string>}>}>>} $data */
     public function __construct(array $data)
     {
         [$this->staticRouteMap, $this->variableRouteData] = $data;
@@ -23,13 +23,11 @@ abstract class RegexBasedAbstract implements Dispatcher
     /**
      * @param mixed[] $routeData
      *
-     * @return mixed[]|null
+     * @return array{0: int, 1?: list<string>|mixed, 2?: array<string, string>}|null
      */
     abstract protected function dispatchVariableRoute(array $routeData, string $uri): ?array;
 
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     public function dispatch(string $httpMethod, string $uri): array
     {
         if (isset($this->staticRouteMap[$httpMethod][$uri])) {

--- a/src/Dispatcher/RegexBasedAbstract.php
+++ b/src/Dispatcher/RegexBasedAbstract.php
@@ -23,9 +23,9 @@ abstract class RegexBasedAbstract implements Dispatcher
     /**
      * @param mixed[] $routeData
      *
-     * @return mixed[]
+     * @return mixed[]|null
      */
-    abstract protected function dispatchVariableRoute(array $routeData, string $uri): array;
+    abstract protected function dispatchVariableRoute(array $routeData, string $uri): ?array;
 
     /**
      * {@inheritDoc}
@@ -41,7 +41,7 @@ abstract class RegexBasedAbstract implements Dispatcher
         $varRouteData = $this->variableRouteData;
         if (isset($varRouteData[$httpMethod])) {
             $result = $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
-            if ($result[0] === self::FOUND) {
+            if ($result !== null) {
                 return $result;
             }
         }
@@ -56,7 +56,7 @@ abstract class RegexBasedAbstract implements Dispatcher
 
             if (isset($varRouteData['GET'])) {
                 $result = $this->dispatchVariableRoute($varRouteData['GET'], $uri);
-                if ($result[0] === self::FOUND) {
+                if ($result !== null) {
                     return $result;
                 }
             }
@@ -71,7 +71,7 @@ abstract class RegexBasedAbstract implements Dispatcher
 
         if (isset($varRouteData['*'])) {
             $result = $this->dispatchVariableRoute($varRouteData['*'], $uri);
-            if ($result[0] === self::FOUND) {
+            if ($result !== null) {
                 return $result;
             }
         }
@@ -93,7 +93,7 @@ abstract class RegexBasedAbstract implements Dispatcher
             }
 
             $result = $this->dispatchVariableRoute($routeData, $uri);
-            if ($result[0] !== self::FOUND) {
+            if ($result === null) {
                 continue;
             }
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -11,15 +11,15 @@ class Route
 
     public string $regex;
 
-    /** @var mixed[] */
+    /** @var array<string, string> */
     public array $variables;
 
     /** @var mixed */
     public $handler;
 
     /**
-     * @param mixed   $handler
-     * @param mixed[] $variables
+     * @param mixed                 $handler
+     * @param array<string, string> $variables
      */
     public function __construct(string $httpMethod, $handler, string $regex, array $variables)
     {

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -136,7 +136,7 @@ class RouteCollector
     /**
      * Returns the collected route data, as provided by the data generator.
      *
-     * @return mixed[]
+     * @return array{0: array<string, array<string, mixed>>, 1: array<string, array<array{regex: string, suffix?: string, routeMap: array<int|string, array{0: mixed, 1: array<string, string>}>}>>}
      */
     public function getData(): array
     {

--- a/src/RouteParser/Std.php
+++ b/src/RouteParser/Std.php
@@ -36,9 +36,7 @@ REGEX;
 
     public const DEFAULT_DISPATCH_REGEX = '[^/]+';
 
-    /**
-     * {@inheritDoc}
-     */
+    /** @inheritDoc */
     public function parse(string $route): array
     {
         $routeWithoutClosingOptionals = rtrim($route, ']');


### PR DESCRIPTION
These are the results when comparing to `master`:

```
+-----------------+--------------------+----------------------------+------+-----+-----------------+-----------------+-----------------+
| benchmark       | subject            | set                        | revs | its | mem_peak        | mode            | rstdev          |
+-----------------+--------------------+----------------------------+------+-----+-----------------+-----------------+-----------------+
| RealLifeExample | benchStaticRoutes  | group_count,first          | 1000 | 5   | 1.489mb 0.00%   | 0.231μs +0.03%  | ±0.42% +0.00%   |
| RealLifeExample | benchStaticRoutes  | char-count,first           | 1000 | 5   | 1.489mb 0.00%   | 0.232μs +0.03%  | ±0.64% -50.79%  |
| RealLifeExample | benchStaticRoutes  | group-pos,first            | 1000 | 5   | 1.489mb 0.00%   | 0.235μs -0.93%  | ±0.88% -6.31%   |
| RealLifeExample | benchStaticRoutes  | mark,first                 | 1000 | 5   | 1.489mb 0.00%   | 0.231μs -2.17%  | ±0.17% -78.99%  |
| RealLifeExample | benchStaticRoutes  | group_count,last           | 1000 | 5   | 1.489mb 0.00%   | 0.237μs +0.05%  | ±1.46% -34.09%  |
| RealLifeExample | benchStaticRoutes  | char-count,last            | 1000 | 5   | 1.489mb 0.00%   | 0.237μs +0.02%  | ±1.13% -50.58%  |
| RealLifeExample | benchStaticRoutes  | group-pos,last             | 1000 | 5   | 1.489mb 0.00%   | 0.243μs +2.83%  | ±0.85% -22.53%  |
| RealLifeExample | benchStaticRoutes  | mark,last                  | 1000 | 5   | 1.489mb 0.00%   | 0.240μs +1.40%  | ±1.43% -20.32%  |
| RealLifeExample | benchStaticRoutes  | group_count,invalid-method | 1000 | 5   | 1.489mb 0.00%   | 1.380μs -13.89% | ±3.03% +27.62%  |
| RealLifeExample | benchStaticRoutes  | char-count,invalid-method  | 1000 | 5   | 1.489mb 0.00%   | 1.546μs -4.26%  | ±2.44% +0.10%   |
| RealLifeExample | benchStaticRoutes  | group-pos,invalid-method   | 1000 | 5   | 1.489mb 0.00%   | 1.380μs -9.00%  | ±1.92% -21.67%  |
| RealLifeExample | benchStaticRoutes  | mark,invalid-method        | 1000 | 5   | 1.489mb 0.00%   | 1.402μs -9.61%  | ±2.65% +67.96%  |
| RealLifeExample | benchDynamicRoutes | group_count,first          | 1000 | 5   | 1.491mb 0.00%   | 0.719μs +8.76%  | ±1.81% +6.49%   |
| RealLifeExample | benchDynamicRoutes | char-count,first           | 1000 | 5   | 1.491mb 0.00%   | 0.755μs -4.37%  | ±2.12% +21.45%  |
| RealLifeExample | benchDynamicRoutes | group-pos,first            | 1000 | 5   | 1.491mb 0.00%   | 0.690μs -8.44%  | ±1.38% -66.47%  |
| RealLifeExample | benchDynamicRoutes | mark,first                 | 1000 | 5   | 1.491mb 0.00%   | 0.754μs -4.74%  | ±2.03% +1.42%   |
| RealLifeExample | benchDynamicRoutes | group_count,last           | 1000 | 5   | 1.491mb 0.00%   | 1.021μs -3.04%  | ±1.77% +19.69%  |
| RealLifeExample | benchDynamicRoutes | char-count,last            | 1000 | 5   | 1.491mb 0.00%   | 0.978μs +6.54%  | ±2.60% +63.21%  |
| RealLifeExample | benchDynamicRoutes | group-pos,last             | 1000 | 5   | 1.491mb 0.00%   | 1.098μs +1.50%  | ±2.34% +11.24%  |
| RealLifeExample | benchDynamicRoutes | mark,last                  | 1000 | 5   | 1.491mb 0.00%   | 0.874μs -4.10%  | ±1.15% -49.06%  |
| RealLifeExample | benchDynamicRoutes | group_count,invalid-method | 1000 | 5   | 1.489mb 0.00%   | 1.767μs -13.76% | ±1.43% -28.24%  |
| RealLifeExample | benchDynamicRoutes | char-count,invalid-method  | 1000 | 5   | 1.489mb 0.00%   | 1.922μs -8.89%  | ±2.42% +70.46%  |
| RealLifeExample | benchDynamicRoutes | group-pos,invalid-method   | 1000 | 5   | 1.489mb 0.00%   | 1.789μs -11.15% | ±3.13% +60.67%  |
| RealLifeExample | benchDynamicRoutes | mark,invalid-method        | 1000 | 5   | 1.489mb 0.00%   | 1.743μs -11.57% | ±2.80% +11.86%  |
| RealLifeExample | benchOtherRoutes   | group_count,non-existent   | 1000 | 5   | 1.487mb 0.00%   | 1.546μs -12.40% | ±1.92% -23.25%  |
| RealLifeExample | benchOtherRoutes   | char-count,non-existent    | 1000 | 5   | 1.487mb 0.00%   | 1.815μs -5.21%  | ±2.27% -6.54%   |
| RealLifeExample | benchOtherRoutes   | group-pos,non-existent     | 1000 | 5   | 1.487mb 0.00%   | 1.558μs -15.28% | ±2.07% +33.09%  |
| RealLifeExample | benchOtherRoutes   | mark,non-existent          | 1000 | 5   | 1.487mb 0.00%   | 1.574μs -13.39% | ±2.36% -11.24%  |
| RealLifeExample | benchOtherRoutes   | group_count,longest-route  | 1000 | 5   | 1.491mb 0.00%   | 1.340μs -3.32%  | ±2.60% +2.68%   |
| RealLifeExample | benchOtherRoutes   | char-count,longest-route   | 1000 | 5   | 1.491mb 0.00%   | 1.215μs -8.14%  | ±2.47% -8.00%   |
| RealLifeExample | benchOtherRoutes   | group-pos,longest-route    | 1000 | 5   | 1.491mb 0.00%   | 1.304μs -2.37%  | ±2.35% +15.62%  |
| RealLifeExample | benchOtherRoutes   | mark,longest-route         | 1000 | 5   | 1.491mb 0.00%   | 1.374μs -4.87%  | ±3.21% +276.90% |
| ManyRoutes      | benchStaticRoutes  | group_count,first          | 1000 | 5   | 3.578mb -11.43% | 0.237μs -0.02%  | ±0.82% +5.34%   |
| ManyRoutes      | benchStaticRoutes  | char-count,first           | 1000 | 5   | 3.578mb -11.43% | 0.239μs +1.79%  | ±1.03% -7.94%   |
| ManyRoutes      | benchStaticRoutes  | group-pos,first            | 1000 | 5   | 3.578mb -11.43% | 0.233μs -2.29%  | ±0.57% -58.42%  |
| ManyRoutes      | benchStaticRoutes  | mark,first                 | 1000 | 5   | 3.578mb -11.43% | 0.238μs -0.25%  | ±0.86% -21.72%  |
| ManyRoutes      | benchStaticRoutes  | group_count,last           | 1000 | 5   | 3.578mb -11.43% | 0.235μs -2.19%  | ±1.17% +16.78%  |
| ManyRoutes      | benchStaticRoutes  | char-count,last            | 1000 | 5   | 3.578mb -11.43% | 0.241μs +0.62%  | ±1.10% +0.41%   |
| ManyRoutes      | benchStaticRoutes  | group-pos,last             | 1000 | 5   | 3.578mb -11.43% | 0.240μs -0.65%  | ±1.20% -27.87%  |
| ManyRoutes      | benchStaticRoutes  | mark,last                  | 1000 | 5   | 3.578mb -11.43% | 0.233μs -2.67%  | ±1.31% -31.40%  |
| ManyRoutes      | benchStaticRoutes  | group_count,invalid-method | 1000 | 5   | 3.577mb -11.43% | 4.119μs -5.36%  | ±2.20% +2.18%   |
| ManyRoutes      | benchStaticRoutes  | char-count,invalid-method  | 1000 | 5   | 3.577mb -11.43% | 2.901μs -7.17%  | ±2.36% -4.04%   |
| ManyRoutes      | benchStaticRoutes  | group-pos,invalid-method   | 1000 | 5   | 3.577mb -11.43% | 4.162μs -2.93%  | ±2.03% -10.72%  |
| ManyRoutes      | benchStaticRoutes  | mark,invalid-method        | 1000 | 5   | 3.577mb -11.43% | 2.489μs -1.07%  | ±1.43% -26.91%  |
| ManyRoutes      | benchDynamicRoutes | group_count,first          | 1000 | 5   | 3.579mb -11.43% | 0.630μs -0.86%  | ±1.76% +189.23% |
| ManyRoutes      | benchDynamicRoutes | char-count,first           | 1000 | 5   | 3.579mb -11.43% | 0.772μs -1.40%  | ±2.29% +17.04%  |
| ManyRoutes      | benchDynamicRoutes | group-pos,first            | 1000 | 5   | 3.579mb -11.43% | 0.624μs -0.59%  | ±1.48% -7.58%   |
| ManyRoutes      | benchDynamicRoutes | mark,first                 | 1000 | 5   | 3.579mb -11.43% | 0.741μs -0.49%  | ±0.78% -73.54%  |
| ManyRoutes      | benchDynamicRoutes | group_count,last           | 1000 | 5   | 3.579mb -11.43% | 21.148μs +1.15% | ±0.68% -29.20%  |
| ManyRoutes      | benchDynamicRoutes | char-count,last            | 1000 | 5   | 3.579mb -11.43% | 18.749μs -0.63% | ±1.72% -23.48%  |
| ManyRoutes      | benchDynamicRoutes | group-pos,last             | 1000 | 5   | 3.579mb -11.43% | 21.077μs +0.69% | ±1.74% +158.23% |
| ManyRoutes      | benchDynamicRoutes | mark,last                  | 1000 | 5   | 3.579mb -11.43% | 16.300μs +0.49% | ±1.27% +49.84%  |
| ManyRoutes      | benchDynamicRoutes | group_count,invalid-method | 1000 | 5   | 3.578mb -11.43% | 21.144μs -0.42% | ±1.87% -20.71%  |
| ManyRoutes      | benchDynamicRoutes | char-count,invalid-method  | 1000 | 5   | 3.578mb -11.43% | 18.354μs +0.58% | ±2.23% +46.18%  |
| ManyRoutes      | benchDynamicRoutes | group-pos,invalid-method   | 1000 | 5   | 3.578mb -11.43% | 20.772μs -0.91% | ±1.76% +91.66%  |
| ManyRoutes      | benchDynamicRoutes | mark,invalid-method        | 1000 | 5   | 3.577mb -11.43% | 16.278μs -0.69% | ±1.92% +92.16%  |
| ManyRoutes      | benchOtherRoutes   | group_count,non-existent   | 1000 | 5   | 3.576mb -11.44% | 4.961μs -8.43%  | ±1.53% -42.74%  |
| ManyRoutes      | benchOtherRoutes   | char-count,non-existent    | 1000 | 5   | 3.576mb -11.44% | 3.364μs -3.98%  | ±1.63% -25.45%  |
| ManyRoutes      | benchOtherRoutes   | group-pos,non-existent     | 1000 | 5   | 3.576mb -11.44% | 4.892μs -8.22%  | ±2.60% +64.24%  |
| ManyRoutes      | benchOtherRoutes   | mark,non-existent          | 1000 | 5   | 3.576mb -11.44% | 2.635μs -1.82%  | ±2.61% -7.84%   |
+-----------------+--------------------+----------------------------+------+-----+-----------------+-----------------+-----------------+
```