### PR TITLE
Expose the regexp / url matched the route

### DIFF
--- a/src/DataGenerator/CharCountBased.php
+++ b/src/DataGenerator/CharCountBased.php
@@ -27,7 +27,7 @@ class CharCountBased extends RegexBasedAbstract
             $suffix .= "\t";
 
             $regexes[] = '(?:' . $regex . '/(\t{' . $suffixLen . '})\t{' . ($count - $suffixLen) . '})';
-            $routeMap[$suffix] = [$route->handler, $route->variables];
+            $routeMap[$suffix] = [$route->handler, $route->variables, $regex];
         }
 
         $regex = '~^(?|' . implode('|', $regexes) . ')$~';

--- a/src/DataGenerator/GroupCountBased.php
+++ b/src/DataGenerator/GroupCountBased.php
@@ -26,7 +26,7 @@ class GroupCountBased extends RegexBasedAbstract
             $numGroups = max($numGroups, $numVariables);
 
             $regexes[] = $regex . str_repeat('()', $numGroups - $numVariables);
-            $routeMap[$numGroups + 1] = [$route->handler, $route->variables];
+            $routeMap[$numGroups + 1] = [$route->handler, $route->variables, $regex];
 
             ++$numGroups;
         }

--- a/src/DataGenerator/GroupPosBased.php
+++ b/src/DataGenerator/GroupPosBased.php
@@ -21,7 +21,7 @@ class GroupPosBased extends RegexBasedAbstract
         $offset = 1;
         foreach ($regexToRoutesMap as $regex => $route) {
             $regexes[] = $regex;
-            $routeMap[$offset] = [$route->handler, $route->variables];
+            $routeMap[$offset] = [$route->handler, $route->variables, $regex];
 
             $offset += count($route->variables);
         }

--- a/src/DataGenerator/MarkBased.php
+++ b/src/DataGenerator/MarkBased.php
@@ -21,7 +21,7 @@ class MarkBased extends RegexBasedAbstract
 
         foreach ($regexToRoutesMap as $regex => $route) {
             $regexes[] = $regex . '(*MARK:' . $markName . ')';
-            $routeMap[$markName] = [$route->handler, $route->variables];
+            $routeMap[$markName] = [$route->handler, $route->variables, $regex];
 
             ++$markName;
         }

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -16,9 +16,9 @@ interface Dispatcher
      *
      *     [self::NOT_FOUND]
      *     [self::METHOD_NOT_ALLOWED, ['GET', 'OTHER_ALLOWED_METHODS']]
-     *     [self::FOUND, $handler, ['varName' => 'value', ...]]
+     *     [self::FOUND, $handler, ['varName' => 'value', ...], 'route converted to a regexp']
      *
-     * @return array{0: int, 1?: list<string>|mixed, 2?: array<string, string>}
+     * @return array{0: int, 1?: list<string>|mixed, 2?: array<string, string>, 3?: string}
      */
     public function dispatch(string $httpMethod, string $uri): array;
 }

--- a/src/Dispatcher/CharCountBased.php
+++ b/src/Dispatcher/CharCountBased.php
@@ -16,7 +16,7 @@ class CharCountBased extends RegexBasedAbstract
                 continue;
             }
 
-            [$handler, $varNames] = $data['routeMap'][end($matches)];
+            [$handler, $varNames, $regexp] = $data['routeMap'][end($matches)];
 
             $vars = [];
             $i = 0;
@@ -24,7 +24,7 @@ class CharCountBased extends RegexBasedAbstract
                 $vars[$varName] = $matches[++$i];
             }
 
-            return [self::FOUND, $handler, $vars];
+            return [self::FOUND, $handler, $vars, $regexp];
         }
 
         return null;

--- a/src/Dispatcher/GroupCountBased.php
+++ b/src/Dispatcher/GroupCountBased.php
@@ -16,7 +16,7 @@ class GroupCountBased extends RegexBasedAbstract
                 continue;
             }
 
-            [$handler, $varNames] = $data['routeMap'][count($matches)];
+            [$handler, $varNames, $regexp] = $data['routeMap'][count($matches)];
 
             $vars = [];
             $i = 0;
@@ -24,7 +24,7 @@ class GroupCountBased extends RegexBasedAbstract
                 $vars[$varName] = $matches[++$i];
             }
 
-            return [self::FOUND, $handler, $vars];
+            return [self::FOUND, $handler, $vars, $regexp];
         }
 
         return null;

--- a/src/Dispatcher/GroupPosBased.php
+++ b/src/Dispatcher/GroupPosBased.php
@@ -20,14 +20,14 @@ class GroupPosBased extends RegexBasedAbstract
             for ($i = 1; $matches[$i] === ''; ++$i) {
             }
 
-            [$handler, $varNames] = $data['routeMap'][$i];
+            [$handler, $varNames, $regexp] = $data['routeMap'][$i];
 
             $vars = [];
             foreach ($varNames as $varName) {
                 $vars[$varName] = $matches[$i++];
             }
 
-            return [self::FOUND, $handler, $vars];
+            return [self::FOUND, $handler, $vars, $regexp];
         }
 
         return null;

--- a/src/Dispatcher/MarkBased.php
+++ b/src/Dispatcher/MarkBased.php
@@ -15,7 +15,7 @@ class MarkBased extends RegexBasedAbstract
                 continue;
             }
 
-            [$handler, $varNames] = $data['routeMap'][$matches['MARK']];
+            [$handler, $varNames, $regexp] = $data['routeMap'][$matches['MARK']];
 
             $vars = [];
             $i = 0;
@@ -23,7 +23,7 @@ class MarkBased extends RegexBasedAbstract
                 $vars[$varName] = $matches[++$i];
             }
 
-            return [self::FOUND, $handler, $vars];
+            return [self::FOUND, $handler, $vars, $regexp];
         }
 
         return null;

--- a/src/Dispatcher/RegexBasedAbstract.php
+++ b/src/Dispatcher/RegexBasedAbstract.php
@@ -33,7 +33,7 @@ abstract class RegexBasedAbstract implements Dispatcher
         if (isset($this->staticRouteMap[$httpMethod][$uri])) {
             $handler = $this->staticRouteMap[$httpMethod][$uri];
 
-            return [self::FOUND, $handler, []];
+            return [self::FOUND, $handler, [], $uri];
         }
 
         $varRouteData = $this->variableRouteData;
@@ -49,7 +49,7 @@ abstract class RegexBasedAbstract implements Dispatcher
             if (isset($this->staticRouteMap['GET'][$uri])) {
                 $handler = $this->staticRouteMap['GET'][$uri];
 
-                return [self::FOUND, $handler, []];
+                return [self::FOUND, $handler, [], $uri];
             }
 
             if (isset($varRouteData['GET'])) {
@@ -64,7 +64,7 @@ abstract class RegexBasedAbstract implements Dispatcher
         if (isset($this->staticRouteMap['*'][$uri])) {
             $handler = $this->staticRouteMap['*'][$uri];
 
-            return [self::FOUND, $handler, []];
+            return [self::FOUND, $handler, [], $uri];
         }
 
         if (isset($varRouteData['*'])) {

--- a/test/Dispatcher/CachingTest.php
+++ b/test/Dispatcher/CachingTest.php
@@ -44,9 +44,11 @@ final class CachingTest extends TestCase
         $dispatcher = $this->createDispatcher();
         $result = $dispatcher->dispatch('GET', '/admin/1234');
 
+        self::assertCount(4, $result);
         self::assertSame(Dispatcher::FOUND, $result[0]);
         self::assertSame(['admin-page'], $result[1]);
         self::assertSame(['page' => '1234'], $result[2]);
+        self::assertSame('/admin/([^/]+)', $result[3]);
     }
 
     #[PHPUnit\Test]
@@ -55,8 +57,11 @@ final class CachingTest extends TestCase
         $dispatcher = $this->createDispatcher();
         $result = $dispatcher->dispatch('GET', '/testing');
 
+        self::assertCount(4, $result);
         self::assertSame(Dispatcher::FOUND, $result[0]);
         self::assertSame(['test'], $result[1]);
+        self::assertSame([], $result[2]);
+        self::assertSame('/testing', $result[3]);
     }
 
     #[PHPUnit\Test]
@@ -65,6 +70,7 @@ final class CachingTest extends TestCase
         $dispatcher = $this->createDispatcher();
         $result = $dispatcher->dispatch('GET', '/testing2');
 
+        self::assertCount(1, $result);
         self::assertSame(Dispatcher::NOT_FOUND, $result[0]);
     }
 }

--- a/test/Dispatcher/DispatcherTestCase.php
+++ b/test/Dispatcher/DispatcherTestCase.php
@@ -47,11 +47,19 @@ abstract class DispatcherTestCase extends TestCase
         array $argDict = [],
     ): void {
         $dispatcher = simpleDispatcher($callback, $this->generateDispatcherOptions());
-        $info = $dispatcher->dispatch($method, $uri);
+        $result = $dispatcher->dispatch($method, $uri);
 
-        self::assertSame($dispatcher::FOUND, $info[0]);
-        self::assertSame($handler, $info[1]);
-        self::assertSame($argDict, $info[2]);
+        self::assertCount(4, $result);
+        self::assertSame($dispatcher::FOUND, $result[0]);
+        self::assertSame($handler, $result[1]);
+        self::assertSame($argDict, $result[2]);
+        /**
+         * Unable to test the result of generated regexp because captured groups are replaced with a generic pattern
+         * For example, the regexp for '/user/{name}/{id:[0-9]+}' is '/^\/user\/([^\/]+)\/([^\/]+)$/'
+         * But we can test that the result is a string. It also could be empty string if the route is static
+         */
+        /** @phpstan-ignore-next-line */
+        self::assertIsString($result[3]);
     }
 
     #[PHPUnit\Test]
@@ -86,6 +94,7 @@ abstract class DispatcherTestCase extends TestCase
         );
 
         [$routedStatus, $methodArray] = $dispatcher->dispatch($method, $uri);
+        self::assertCount(2, $routeInfo);
         self::assertSame($dispatcher::METHOD_NOT_ALLOWED, $routedStatus);
         self::assertSame($availableMethods, $methodArray);
     }


### PR DESCRIPTION
Partially covers https://github.com/nikic/FastRoute/issues/225 and hypothetically could be covered fully is parser will return both raw and encoded route string.
I'm not sure about the full covering way, but hope at least this changes could help