### PR TITLE
Introduce component to easily configure dispatcher 

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Custom patterns for route placeholders cannot use capturing groups. For example 
 is not a valid placeholder, because `()` is a capturing group. Instead you can use either
 `{lang:en|de}` or `{lang:(?:en|de)}`.
 
-Furthermore parts of the route enclosed in `[...]` are considered optional, so that `/foo[bar]`
+Furthermore, parts of the route enclosed in `[...]` are considered optional, so that `/foo[bar]`
 will match both `/foo` and `/foobar`. Optional parts are only supported in a trailing position,
 not in the middle of a route.
 
@@ -239,7 +239,7 @@ interface Dispatcher {
 ```
 
 The route parser takes a route pattern string and converts it into an array of route infos, where
-each route info is again an array of it's parts. The structure is best understood using an example:
+each route info is again an array of its parts. The structure is best understood using an example:
 
     /* The route /user/{id:\d+}[/{name}] converts to the following array: */
     [

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,6 +23,7 @@
 
     <rule ref="SlevomatCodingStandard.Functions.UnusedParameter">
         <exclude-pattern>src/Dispatcher/Result/*</exclude-pattern>
+        <exclude-pattern>test/FastRouteTest.php</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix">

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,3 +4,7 @@ parameters:
         - benchmark
         - src
         - test
+
+    ignoreErrors:
+        # We're marking this as deprecated, there's no point in alerting ourselves here...
+        - '#Call to deprecated function FastRoute\\(cached|simple)Dispatcher.*#'

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -16,7 +16,7 @@ interface Dispatcher
     /**
      * Dispatches against the provided HTTP method verb and URI.
      *
-     * Returns array with one of the following formats:
+     * Returns an object that also has an array shape with one of the following formats:
      *
      *     [self::NOT_FOUND]
      *     [self::METHOD_NOT_ALLOWED, ['GET', 'OTHER_ALLOWED_METHODS']]

--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute;
+
+use Closure;
+use FastRoute\Cache\FileCache;
+
+use function is_string;
+
+final class FastRoute
+{
+    /**
+     * @param Closure(RouteCollector):void   $routeDefinitionCallback
+     * @param class-string<RouteParser>      $routeParser
+     * @param class-string<DataGenerator>    $dataGenerator
+     * @param class-string<Dispatcher>       $dispatcher
+     * @param class-string<RouteCollector>   $routeCollector
+     * @param Cache|class-string<Cache>|null $cacheDriver
+     */
+    private function __construct(
+        private readonly Closure $routeDefinitionCallback,
+        private readonly string $routeParser,
+        private readonly string $dataGenerator,
+        private readonly string $dispatcher,
+        private readonly string $routeCollector,
+        private readonly Cache|string|null $cacheDriver,
+    ) {
+    }
+
+    /** @param Closure(RouteCollector):void $routeDefinitionCallback */
+    public static function recommendedSettings(Closure $routeDefinitionCallback): self
+    {
+        return new self(
+            $routeDefinitionCallback,
+            RouteParser\Std::class,
+            DataGenerator\MarkBased::class,
+            Dispatcher\MarkBased::class,
+            RouteCollector::class,
+            FileCache::class,
+        );
+    }
+
+    public function disableCache(): self
+    {
+        return new self(
+            $this->routeDefinitionCallback,
+            $this->routeParser,
+            $this->dataGenerator,
+            $this->dispatcher,
+            $this->routeCollector,
+            null,
+        );
+    }
+
+    /** @param Cache|class-string<Cache> $driver */
+    public function withCache(Cache|string $driver): self
+    {
+        return new self(
+            $this->routeDefinitionCallback,
+            $this->routeParser,
+            $this->dataGenerator,
+            $this->dispatcher,
+            $this->routeCollector,
+            $driver,
+        );
+    }
+
+    public function useCharCountDispatcher(): self
+    {
+        return $this->useCustomDispatcher(DataGenerator\CharCountBased::class, Dispatcher\CharCountBased::class);
+    }
+
+    public function useGroupCountDispatcher(): self
+    {
+        return $this->useCustomDispatcher(DataGenerator\GroupCountBased::class, Dispatcher\GroupCountBased::class);
+    }
+
+    public function useGroupPosDispatcher(): self
+    {
+        return $this->useCustomDispatcher(DataGenerator\GroupPosBased::class, Dispatcher\GroupPosBased::class);
+    }
+
+    public function useMarkDispatcher(): self
+    {
+        return $this->useCustomDispatcher(DataGenerator\MarkBased::class, Dispatcher\MarkBased::class);
+    }
+
+    /**
+     * @param class-string<DataGenerator> $dataGenerator
+     * @param class-string<Dispatcher>    $dispatcher
+     */
+    public function useCustomDispatcher(string $dataGenerator, string $dispatcher): self
+    {
+        return new self(
+            $this->routeDefinitionCallback,
+            $this->routeParser,
+            $dataGenerator,
+            $dispatcher,
+            $this->routeCollector,
+            $this->cacheDriver,
+        );
+    }
+
+    public function dispatcher(string $cacheKey): Dispatcher
+    {
+        $loader = function (): array {
+            $collector = new $this->routeCollector(
+                new $this->routeParser(),
+                new $this->dataGenerator(),
+            );
+
+            ($this->routeDefinitionCallback)($collector);
+
+            return $collector->getData();
+        };
+
+        if ($this->cacheDriver === null) {
+            return new $this->dispatcher($loader());
+        }
+
+        $cache = is_string($this->cacheDriver)
+            ? new $this->cacheDriver()
+            : $this->cacheDriver;
+
+        return new $this->dispatcher($cache->get($cacheKey, $loader));
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -10,7 +10,14 @@ use function function_exists;
 use function is_string;
 
 if (! function_exists('FastRoute\simpleDispatcher')) {
-    /** @param array{routeParser?: class-string<RouteParser>, dataGenerator?: class-string<DataGenerator>, dispatcher?: class-string<Dispatcher>, routeCollector?: class-string<RouteCollector>, cacheDisabled?: bool, cacheKey?: string, cacheFile?: string, cacheDriver?: class-string<Cache>|Cache} $options */
+    /**
+     * @deprecated since v2.0 and will be removed in v3.0
+     *
+     * @see FastRoute::recommendedSettings()
+     * @see FastRoute::disableCache()
+     *
+     * @param array{routeParser?: class-string<RouteParser>, dataGenerator?: class-string<DataGenerator>, dispatcher?: class-string<Dispatcher>, routeCollector?: class-string<RouteCollector>, cacheDisabled?: bool, cacheKey?: string, cacheFile?: string, cacheDriver?: class-string<Cache>|Cache} $options
+     */
     function simpleDispatcher(callable $routeDefinitionCallback, array $options = []): Dispatcher
     {
         return \FastRoute\cachedDispatcher(
@@ -19,7 +26,13 @@ if (! function_exists('FastRoute\simpleDispatcher')) {
         );
     }
 
-    /** @param array{routeParser?: class-string<RouteParser>, dataGenerator?: class-string<DataGenerator>, dispatcher?: class-string<Dispatcher>, routeCollector?: class-string<RouteCollector>, cacheDisabled?: bool, cacheKey?: string, cacheFile?: string, cacheDriver?: class-string<Cache>|Cache} $options */
+    /**
+     * @deprecated since v2.0 and will be removed in v3.0
+     *
+     * @see FastRoute::recommendedSettings()
+     *
+     * @param array{routeParser?: class-string<RouteParser>, dataGenerator?: class-string<DataGenerator>, dispatcher?: class-string<Dispatcher>, routeCollector?: class-string<RouteCollector>, cacheDisabled?: bool, cacheKey?: string, cacheFile?: string, cacheDriver?: class-string<Cache>|Cache} $options
+     */
     function cachedDispatcher(callable $routeDefinitionCallback, array $options = []): Dispatcher
     {
         $options += [

--- a/test/FastRouteTest.php
+++ b/test/FastRouteTest.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute\Test;
+
+use FastRoute\Cache;
+use FastRoute\Dispatcher;
+use FastRoute\FastRoute;
+use FastRoute\RouteCollector;
+use PHPUnit\Framework\Attributes as PHPUnit;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class FastRouteTest extends TestCase
+{
+    #[PHPUnit\Test]
+    public function markShouldBeTheDefaultDispatcher(): void
+    {
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+            ->disableCache()
+            ->dispatcher('test');
+
+        self::assertInstanceOf(Dispatcher\MarkBased::class, $dispatcher);
+    }
+
+    #[PHPUnit\Test]
+    public function canBeConfiguredToUseCharCountDispatcher(): void
+    {
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+            ->disableCache()
+            ->useCharCountDispatcher()
+            ->dispatcher('test');
+
+        self::assertInstanceOf(Dispatcher\CharCountBased::class, $dispatcher);
+    }
+
+    #[PHPUnit\Test]
+    public function canBeConfiguredToUseGroupPosDispatcher(): void
+    {
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+            ->disableCache()
+            ->useGroupPosDispatcher()
+            ->dispatcher('test');
+
+        self::assertInstanceOf(Dispatcher\GroupPosBased::class, $dispatcher);
+    }
+
+    #[PHPUnit\Test]
+    public function canBeConfiguredToUseGroupCountDispatcher(): void
+    {
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+            ->disableCache()
+            ->useGroupCountDispatcher()
+            ->dispatcher('test');
+
+        self::assertInstanceOf(Dispatcher\GroupCountBased::class, $dispatcher);
+    }
+
+    #[PHPUnit\Test]
+    public function canBeConfiguredToUseMarkDispatcher(): void
+    {
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+            ->disableCache()
+            ->useCharCountDispatcher()
+            ->useMarkDispatcher()
+            ->dispatcher('test');
+
+        self::assertInstanceOf(Dispatcher\MarkBased::class, $dispatcher);
+    }
+
+    #[PHPUnit\Test]
+    public function canBeConfiguredToUseCustomCache(): void
+    {
+        $cache = new class () implements Cache {
+            /** @inheritDoc */
+            public function get(string $key, callable $loader): array
+            {
+                if ($key === 'test') {
+                    return [['GET' => ['/' => ['test2', ['test' => true]]]], []];
+                }
+
+                throw new RuntimeException('This dummy implementation is not meant for other cases');
+            }
+        };
+
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+            ->withCache($cache)
+            ->dispatcher('test');
+
+        $result = $dispatcher->dispatch('GET', '/');
+
+        self::assertInstanceOf(Dispatcher\Result\Matched::class, $result);
+        self::assertSame('test2', $result->handler); // should use data from cache, not from loader
+        self::assertSame(['test' => true], $result->extraParameters); // should use data from cache, not from loader
+    }
+
+    private static function routes(RouteCollector $collector): void
+    {
+        $collector->get('/', 'test');
+    }
+}


### PR DESCRIPTION
This promotes more a explicit design for initialising the dispatcher, reducing the possibility of introducing mistakes when switching between implementations.