### PR TITLE
Implement URI generation for named routes

### DIFF
--- a/benchmark/UriGenerationBench.php
+++ b/benchmark/UriGenerationBench.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute\Benchmark;
+
+use FastRoute\ConfigureRoutes;
+use FastRoute\FastRoute;
+use FastRoute\GenerateUri;
+use PhpBench\Attributes as Bench;
+
+/** @phpstan-import-type UriSubstitutions from GenerateUri */
+#[Bench\Iterations(5)]
+#[Bench\Revs(250)]
+#[Bench\Warmup(3)]
+#[Bench\BeforeMethods(['registerGenerator'])]
+final class UriGenerationBench
+{
+    private GenerateUri $generator;
+
+    public function registerGenerator(): void
+    {
+        $loader = static function (ConfigureRoutes $routes): void {
+            $routes->addRoute('GET', '/', 'do-something', ['_name' => 'home']);
+            $routes->addRoute('GET', '/page/{page_slug:[a-zA-Z0-9\-]+}', 'do-something', ['_name' => 'page.show']);
+            $routes->addRoute('GET', '/about-us', 'do-something', ['_name' => 'about-us']);
+            $routes->addRoute('GET', '/contact-us', 'do-something', ['_name' => 'contact-us']);
+            $routes->addRoute('POST', '/contact-us', 'do-something', ['_name' => 'contact-us.submit']);
+            $routes->addRoute('GET', '/blog', 'do-something', ['_name' => 'blog.index']);
+            $routes->addRoute('GET', '/blog/recent', 'do-something', ['_name' => 'blog.recent']);
+            $routes->addRoute('GET', '/blog/{year}[/{month}[/{day}]]', 'do-something', ['_name' => 'blog.archive']);
+            $routes->addRoute('GET', '/blog/post/{post_slug:[a-zA-Z0-9\-]+}', 'do-something', ['_name' => 'blog.post.show']);
+            $routes->addRoute('POST', '/blog/post/{post_slug:[a-zA-Z0-9\-]+}/comment', 'do-something', ['_name' => 'blog.post.comment']);
+            $routes->addRoute('GET', '/shop', 'do-something', ['_name' => 'shop.index']);
+            $routes->addRoute('GET', '/shop/category', 'do-something', ['_name' => 'shop.category.index']);
+            $routes->addRoute('GET', '/shop/category/{category_id:\d+}/product/search/{filter_by:[a-zA-Z]+}:{filter_value}', 'do-something', ['_name' => 'shop.category.product.search']);
+        };
+
+        $this->generator = FastRoute::recommendedSettings($loader, 'cache')
+            ->disableCache()
+            ->uriGenerator();
+    }
+
+    /** @param array{name: non-empty-string} $params */
+    #[Bench\Subject]
+    #[Bench\ParamProviders(['allStaticRoutes'])]
+    public function staticRoutes(array $params): void
+    {
+        $this->generator->forRoute($params['name']);
+    }
+
+    /** @return iterable<non-empty-string, array{name: non-empty-string}> */
+    public static function allStaticRoutes(): iterable
+    {
+        $staticRoutes = [
+            'home',
+            'about-us',
+            'contact-us',
+            'contact-us.submit',
+            'blog.index',
+            'blog.recent',
+            'shop.index',
+            'shop.category.index',
+        ];
+
+        foreach ($staticRoutes as $route) {
+            yield $route => ['name' => $route];
+        }
+    }
+
+    /** @param array{name: non-empty-string, substitutions: UriSubstitutions} $params */
+    #[Bench\Subject]
+    #[Bench\ParamProviders(['allDynamicRoutes'])]
+    public function dynamicRoutes(array $params): void
+    {
+        $this->generator->forRoute($params['name'], $params['substitutions']);
+    }
+
+    /** @return iterable<non-empty-string, array{name: non-empty-string, substitutions: UriSubstitutions}> */
+    public static function allDynamicRoutes(): iterable
+    {
+        yield 'page.show' => ['name' => 'page.show', 'substitutions' => ['page_slug' => 'testing-one-two-three']];
+
+        yield 'blog.post.show' => ['name' => 'blog.post.show', 'substitutions' => ['post_slug' => 'testing-one-two-three']];
+        yield 'blog.post.comment' => ['name' => 'blog.post.comment', 'substitutions' => ['post_slug' => 'testing-one-two-three']];
+        yield 'blog.archive-year' => ['name' => 'blog.archive', 'substitutions' => ['year' => '2014']];
+        yield 'blog.archive-year-month' => ['name' => 'blog.archive', 'substitutions' => ['year' => '2014', 'month' => '03']];
+        yield 'blog.archive-year-day' => ['name' => 'blog.archive', 'substitutions' => ['year' => '2014', 'month' => '03', 'day' => '15']];
+
+        yield 'shop.category.product.search' => ['name' => 'shop.category.product.search', 'substitutions' => ['category_id' => '1', 'filter_by' => 'name', 'filter_value' => 'testing']];
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -916,16 +916,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.57",
+            "version": "1.10.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e"
+                "reference": "a23518379ec4defd9e47cbf81019526861623ec2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1627b1d03446904aaa77593f370c5201d2ecc34e",
-                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a23518379ec4defd9e47cbf81019526861623ec2",
+                "reference": "a23518379ec4defd9e47cbf81019526861623ec2",
                 "shasum": ""
             },
             "require": {
@@ -974,7 +974,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-24T11:51:34+00:00"
+            "time": "2024-02-12T20:02:57+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -2616,16 +2616,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "76d449a358ece77d6f1d6331c68453e657172202"
+                "reference": "9bb7db07b5d66d90f6ebf542f09fc67d800e5259"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/76d449a358ece77d6f1d6331c68453e657172202",
-                "reference": "76d449a358ece77d6f1d6331c68453e657172202",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9bb7db07b5d66d90f6ebf542f09fc67d800e5259",
+                "reference": "9bb7db07b5d66d90f6ebf542f09fc67d800e5259",
                 "shasum": ""
             },
             "require": {
@@ -2664,7 +2664,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.10.1"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.10.2"
             },
             "funding": [
                 {
@@ -2676,7 +2676,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-18T13:03:25+00:00"
+            "time": "2024-02-07T12:57:50+00:00"
         },
         {
             "name": "slevomat/coding-standard",

--- a/src/BadRouteException.php
+++ b/src/BadRouteException.php
@@ -8,7 +8,7 @@ use LogicException;
 use function sprintf;
 
 /** @final */
-class BadRouteException extends LogicException
+class BadRouteException extends LogicException implements Exception
 {
     public static function alreadyRegistered(string $route, string $method): self
     {

--- a/src/BadRouteException.php
+++ b/src/BadRouteException.php
@@ -6,6 +6,7 @@ namespace FastRoute;
 use LogicException;
 
 use function sprintf;
+use function var_export;
 
 /** @final */
 class BadRouteException extends LogicException implements Exception
@@ -13,6 +14,16 @@ class BadRouteException extends LogicException implements Exception
     public static function alreadyRegistered(string $route, string $method): self
     {
         return new self(sprintf('Cannot register two routes matching "%s" for method "%s"', $route, $method));
+    }
+
+    public static function namedRouteAlreadyDefined(string $name): self
+    {
+        return new self(sprintf('Cannot register two routes under the name "%s"', $name));
+    }
+
+    public static function invalidRouteName(mixed $name): self
+    {
+        return new self(sprintf('Route name must be a non-empty string, "%s" given', var_export($name, true)));
     }
 
     public static function shadowedByVariableRoute(string $route, string $shadowedRegex, string $method): self

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace FastRoute;
 
-/** @phpstan-import-type RouteData from DataGenerator */
+/** @phpstan-import-type ProcessedData from ConfigureRoutes */
 interface Cache
 {
     /**
-     * @param callable():RouteData $loader
+     * @param callable():ProcessedData $loader
      *
-     * @return RouteData
+     * @return ProcessedData
      */
     public function get(string $key, callable $loader): array;
 }

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -5,7 +5,7 @@ namespace FastRoute\Cache;
 
 use Closure;
 use FastRoute\Cache;
-use FastRoute\DataGenerator;
+use FastRoute\ConfigureRoutes;
 use RuntimeException;
 
 use function chmod;
@@ -23,7 +23,7 @@ use function var_export;
 
 use const LOCK_EX;
 
-/** @phpstan-import-type RouteData from DataGenerator */
+/** @phpstan-import-type ProcessedData from ConfigureRoutes */
 final class FileCache implements Cache
 {
     private const DIRECTORY_PERMISSIONS = 0775;
@@ -55,7 +55,7 @@ final class FileCache implements Cache
         return $data;
     }
 
-    /** @return RouteData|null */
+    /** @return ProcessedData|null */
     private static function readFileContents(string $path): ?array
     {
         // error suppression is faster than calling `file_exists()` + `is_file()` + `is_readable()`, especially because there's no need to error here

--- a/src/Cache/Psr16Cache.php
+++ b/src/Cache/Psr16Cache.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 namespace FastRoute\Cache;
 
 use FastRoute\Cache;
-use FastRoute\DataGenerator;
 use Psr\SimpleCache\CacheInterface;
 
 use function is_array;
 
-/** @phpstan-import-type RouteData from DataGenerator */
 final class Psr16Cache implements Cache
 {
     public function __construct(private readonly CacheInterface $cache)

--- a/src/ConfigureRoutes.php
+++ b/src/ConfigureRoutes.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 namespace FastRoute;
 
 /**
- * @phpstan-import-type RouteData from DataGenerator
+ * @phpstan-import-type StaticRoutes from DataGenerator
+ * @phpstan-import-type DynamicRoutes from DataGenerator
  * @phpstan-import-type ExtraParameters from DataGenerator
+ * @phpstan-type ProcessedData array{StaticRoutes, DynamicRoutes}
  */
 interface ConfigureRoutes
 {
@@ -104,7 +106,7 @@ interface ConfigureRoutes
     /**
      * Returns the processed aggregated route data.
      *
-     * @return RouteData
+     * @return ProcessedData
      */
     public function processedRoutes(): array;
 }

--- a/src/ConfigureRoutes.php
+++ b/src/ConfigureRoutes.php
@@ -9,6 +9,9 @@ namespace FastRoute;
  */
 interface ConfigureRoutes
 {
+    public const ROUTE_NAME = '_name';
+    public const ROUTE_REGEX = '_route';
+
     /**
      * Registers a new route.
      *

--- a/src/ConfigureRoutes.php
+++ b/src/ConfigureRoutes.php
@@ -7,7 +7,8 @@ namespace FastRoute;
  * @phpstan-import-type StaticRoutes from DataGenerator
  * @phpstan-import-type DynamicRoutes from DataGenerator
  * @phpstan-import-type ExtraParameters from DataGenerator
- * @phpstan-type ProcessedData array{StaticRoutes, DynamicRoutes}
+ * @phpstan-import-type RoutesForUriGeneration from GenerateUri
+ * @phpstan-type ProcessedData array{StaticRoutes, DynamicRoutes, RoutesForUriGeneration}
  */
 interface ConfigureRoutes
 {

--- a/src/DataGenerator.php
+++ b/src/DataGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace FastRoute;
 
 /**
+ * @phpstan-import-type ParsedRoute from RouteParser
  * @phpstan-type ExtraParameters array<string, string|int|bool|float>
  * @phpstan-type StaticRoutes array<string, array<string, array{mixed, ExtraParameters}>>
  * @phpstan-type DynamicRouteChunk array{regex: string, suffix?: string, routeMap: array<int|string, array{mixed, array<string, string>, ExtraParameters}>}
@@ -21,8 +22,8 @@ interface DataGenerator
      * can be arbitrary data that will be returned when the route
      * matches.
      *
-     * @param array<string|array{0: string, 1:string}> $routeData
-     * @param ExtraParameters                          $extraParameters
+     * @param ParsedRoute     $routeData
+     * @param ExtraParameters $extraParameters
      */
     public function addRoute(string $httpMethod, array $routeData, mixed $handler, array $extraParameters = []): void;
 

--- a/src/DataGenerator/RegexBasedAbstract.php
+++ b/src/DataGenerator/RegexBasedAbstract.php
@@ -6,6 +6,7 @@ namespace FastRoute\DataGenerator;
 use FastRoute\BadRouteException;
 use FastRoute\DataGenerator;
 use FastRoute\Route;
+use FastRoute\RouteParser;
 
 use function array_chunk;
 use function array_map;
@@ -24,6 +25,7 @@ use function round;
  * @phpstan-import-type DynamicRoutes from DataGenerator
  * @phpstan-import-type RouteData from DataGenerator
  * @phpstan-import-type ExtraParameters from DataGenerator
+ * @phpstan-import-type ParsedRoute from RouteParser
  */
 abstract class RegexBasedAbstract implements DataGenerator
 {
@@ -85,15 +87,15 @@ abstract class RegexBasedAbstract implements DataGenerator
         return $size;
     }
 
-    /** @param array<string|array{0: string, 1:string}> $routeData */
+    /** @param ParsedRoute $routeData */
     private function isStaticRoute(array $routeData): bool
     {
         return count($routeData) === 1 && is_string($routeData[0]);
     }
 
     /**
-     * @param array<string|array{0: string, 1:string}> $routeData
-     * @param ExtraParameters                          $extraParameters
+     * @param ParsedRoute     $routeData
+     * @param ExtraParameters $extraParameters
      */
     private function addStaticRoute(string $httpMethod, array $routeData, mixed $handler, array $extraParameters): void
     {
@@ -116,8 +118,8 @@ abstract class RegexBasedAbstract implements DataGenerator
     }
 
     /**
-     * @param array<string|array{0: string, 1:string}> $routeData
-     * @param ExtraParameters                          $extraParameters
+     * @param ParsedRoute     $routeData
+     * @param ExtraParameters $extraParameters
      */
     private function addVariableRoute(string $httpMethod, array $routeData, mixed $handler, array $extraParameters): void
     {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute;
+
+use Throwable;
+
+interface Exception extends Throwable
+{
+}

--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -9,9 +9,12 @@ use FastRoute\Cache\FileCache;
 use function assert;
 use function is_string;
 
-/** @phpstan-import-type RouteData from DataGenerator */
+/** @phpstan-import-type ProcessedData from ConfigureRoutes */
 final class FastRoute
 {
+    /** @var ProcessedData|null */
+    private ?array $processedConfiguration = null;
+
     /**
      * @param Closure(ConfigureRoutes):void  $routeDefinitionCallback
      * @param class-string<RouteParser>      $routeParser
@@ -109,7 +112,7 @@ final class FastRoute
         );
     }
 
-    /** @return RouteData */
+    /** @return ProcessedData */
     private function buildConfiguration(): array
     {
         $loader = function (): array {

--- a/src/FastRoute.php
+++ b/src/FastRoute.php
@@ -22,6 +22,7 @@ final class FastRoute
      * @param class-string<Dispatcher>       $dispatcher
      * @param class-string<ConfigureRoutes>  $routesConfiguration
      * @param Cache|class-string<Cache>|null $cacheDriver
+     * @param non-empty-string|null          $cacheKey
      */
     private function __construct(
         private readonly Closure $routeDefinitionCallback,
@@ -34,7 +35,10 @@ final class FastRoute
     ) {
     }
 
-    /** @param Closure(ConfigureRoutes):void $routeDefinitionCallback */
+    /**
+     * @param Closure(ConfigureRoutes):void $routeDefinitionCallback
+     * @param non-empty-string              $cacheKey
+     */
     public static function recommendedSettings(Closure $routeDefinitionCallback, string $cacheKey): self
     {
         return new self(
@@ -61,7 +65,10 @@ final class FastRoute
         );
     }
 
-    /** @param Cache|class-string<Cache> $driver */
+    /**
+     * @param Cache|class-string<Cache> $driver
+     * @param non-empty-string          $cacheKey
+     */
     public function withCache(Cache|string $driver, string $cacheKey): self
     {
         return new self(

--- a/src/GenerateUri.php
+++ b/src/GenerateUri.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute;
+
+use FastRoute\GenerateUri\UriCouldNotBeGenerated;
+
+/**
+ * @phpstan-import-type ParsedRoutes from RouteParser
+ * @phpstan-type RoutesForUriGeneration array<non-empty-string, ParsedRoutes>
+ * @phpstan-type UriSubstitutions array<non-empty-string, non-empty-string>
+ */
+interface GenerateUri
+{
+    /**
+     * @param UriSubstitutions $substitutions
+     *
+     * @throws UriCouldNotBeGenerated
+     */
+    public function forRoute(string $name, array $substitutions = []): string;
+}

--- a/src/GenerateUri/FromProcessedConfiguration.php
+++ b/src/GenerateUri/FromProcessedConfiguration.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute\GenerateUri;
+
+use FastRoute\GenerateUri;
+use FastRoute\RouteParser;
+
+use function array_key_exists;
+use function array_keys;
+use function assert;
+use function count;
+use function is_string;
+use function preg_match;
+
+/**
+ * @phpstan-import-type RoutesForUriGeneration from GenerateUri
+ * @phpstan-import-type UriSubstitutions from GenerateUri
+ * @phpstan-import-type ParsedRoute from RouteParser
+ */
+final class FromProcessedConfiguration implements GenerateUri
+{
+    /** @param RoutesForUriGeneration $processedConfiguration */
+    public function __construct(private readonly array $processedConfiguration)
+    {
+    }
+
+    /** @inheritDoc */
+    public function forRoute(string $name, array $substitutions = []): string
+    {
+        if (! array_key_exists($name, $this->processedConfiguration)) {
+            throw UriCouldNotBeGenerated::routeIsUndefined($name);
+        }
+
+        $missingParameters = [];
+
+        foreach ($this->processedConfiguration[$name] as $parsedRoute) {
+            $missingParameters = $this->missingParameters($parsedRoute, $substitutions);
+
+            // Only attempt to generate the path if we have the necessary info
+            if (count($missingParameters) === 0) {
+                return $this->generatePath($name, $parsedRoute, $substitutions);
+            }
+        }
+
+        assert(count($missingParameters) > 0);
+
+        throw UriCouldNotBeGenerated::insufficientParameters(
+            $name,
+            $missingParameters,
+            array_keys($substitutions),
+        );
+    }
+
+    /**
+     * Returns the expected parameters that were not passed as substitutions
+     *
+     * @param ParsedRoute      $parts
+     * @param UriSubstitutions $substitutions
+     *
+     * @return list<string>
+     */
+    private function missingParameters(array $parts, array $substitutions): array
+    {
+        $missingParameters = [];
+
+        foreach ($parts as $part) {
+            if (is_string($part) || array_key_exists($part[0], $substitutions)) {
+                continue;
+            }
+
+            $missingParameters[] = $part[0];
+        }
+
+        return $missingParameters;
+    }
+
+    /**
+     * @param ParsedRoute      $parsedRoute
+     * @param UriSubstitutions $substitutions
+     */
+    private function generatePath(string $route, array $parsedRoute, array $substitutions): string
+    {
+        $path = '';
+
+        foreach ($parsedRoute as $part) {
+            if (is_string($part)) {
+                $path .= $part;
+
+                continue;
+            }
+
+            [$parameterName, $regex] = $part;
+
+            if (preg_match('~^' . $regex . '$~u', $substitutions[$parameterName]) !== 1) {
+                throw UriCouldNotBeGenerated::parameterDoesNotMatchThePattern($route, $parameterName, $regex);
+            }
+
+            $path .= $substitutions[$parameterName];
+        }
+
+        return $path;
+    }
+}

--- a/src/GenerateUri/UriCouldNotBeGenerated.php
+++ b/src/GenerateUri/UriCouldNotBeGenerated.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute\GenerateUri;
+
+use FastRoute\Exception;
+use LogicException;
+
+use function count;
+use function implode;
+use function sprintf;
+
+final class UriCouldNotBeGenerated extends LogicException implements Exception
+{
+    public static function routeIsUndefined(string $name): self
+    {
+        return new self('There is no route with name "' . $name . '" defined');
+    }
+
+    public static function parameterDoesNotMatchThePattern(
+        string $route,
+        string $parameter,
+        string $expectedPattern,
+    ): self {
+        return new self(
+            sprintf(
+                'Route "%s" expects the parameter [%s] to match the regex `%s`',
+                $route,
+                $parameter,
+                $expectedPattern,
+            ),
+        );
+    }
+
+    /**
+     * @param non-empty-list<string> $missingParameters
+     * @param list<string>           $givenParameters
+     */
+    public static function insufficientParameters(
+        string $route,
+        array $missingParameters,
+        array $givenParameters,
+    ): self {
+        return new self(
+            sprintf(
+                'Route "%s" expects at least parameter values for [%s], but received %s',
+                $route,
+                implode(',', $missingParameters),
+                count($givenParameters) === 0 ? 'none' : '[' . implode(',', $givenParameters) . ']',
+            ),
+        );
+    }
+}

--- a/src/Route.php
+++ b/src/Route.php
@@ -11,6 +11,7 @@ use function preg_quote;
  * @internal
  *
  * @phpstan-import-type ExtraParameters from DataGenerator
+ * @phpstan-import-type ParsedRoute from RouteParser
  */
 class Route
 {
@@ -20,8 +21,8 @@ class Route
     public readonly array $variables;
 
     /**
-     * @param array<string|array{0: string, 1:string}> $routeData
-     * @param ExtraParameters                          $extraParameters
+     * @param ParsedRoute     $routeData
+     * @param ExtraParameters $extraParameters
      */
     public function __construct(
         public readonly string $httpMethod,
@@ -33,9 +34,9 @@ class Route
     }
 
     /**
-     * @param array<string|array{0: string, 1:string}> $routeData
+     * @param ParsedRoute $routeData
      *
-     * @return array{0: string, 1: array<string, string>}
+     * @return array{string, array<string, string>}
      */
     private static function extractRegex(array $routeData): array
     {

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace FastRoute;
 
 /**
- * @phpstan-import-type RouteData from DataGenerator
+ * @phpstan-import-type ProcessedData from ConfigureRoutes
  * @phpstan-import-type ExtraParameters from DataGenerator
  * @final
  */
@@ -100,7 +100,7 @@ class RouteCollector implements ConfigureRoutes
      *
      * @see ConfigureRoutes::processedRoutes()
      *
-     * @return RouteData
+     * @return ProcessedData
      */
     public function getData(): array
     {

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -24,7 +24,7 @@ class RouteCollector implements ConfigureRoutes
         $route = $this->currentGroupPrefix . $route;
         $parsedRoutes = $this->routeParser->parse($route);
 
-        $extraParameters = ['_route' => $route] + $extraParameters;
+        $extraParameters = [self::ROUTE_REGEX => $route] + $extraParameters;
 
         foreach ((array) $httpMethod as $method) {
             foreach ($parsedRoutes as $parsedRoute) {

--- a/src/RouteParser.php
+++ b/src/RouteParser.php
@@ -3,6 +3,10 @@ declare(strict_types=1);
 
 namespace FastRoute;
 
+/**
+ * @phpstan-type ParsedRoute array<string|array{string, string}>
+ * @phpstan-type ParsedRoutes list<ParsedRoute>
+ */
 interface RouteParser
 {
     /**
@@ -32,7 +36,7 @@ interface RouteParser
      *
      * @param string $route Route string to parse
      *
-     * @return list<array<string|array{0: string, 1:string}>> Array of route data arrays
+     * @return ParsedRoutes Array of route data arrays
      */
     public function parse(string $route): array;
 }

--- a/src/RouteParser/Std.php
+++ b/src/RouteParser/Std.php
@@ -27,6 +27,7 @@ use const PREG_SET_ORDER;
  *
  * "/user/{name}[/{id:[0-9]+}]"
  *
+ * @phpstan-import-type ParsedRoute from RouteParser
  * @final
  */
 class Std implements RouteParser
@@ -91,7 +92,7 @@ REGEX;
     /**
      * Parses a route string that does not contain optional segments.
      *
-     * @return array<string|array{0: string, 1:string}>
+     * @return ParsedRoute
      */
     private function parsePlaceholders(string $route): array
     {

--- a/test/Cache/Psr16CacheTest.php
+++ b/test/Cache/Psr16CacheTest.php
@@ -15,7 +15,7 @@ final class Psr16CacheTest extends TestCase
     {
         $data = [];
 
-        $generatedData = [['GET' => ['/' => ['test', []]]], []];
+        $generatedData = [['GET' => ['/' => ['test', []]]], [], []];
 
         $adapter = new Psr16Cache($this->createDummyCache($data));
         $result = $adapter->get('test', static fn () => $generatedData);
@@ -24,7 +24,7 @@ final class Psr16CacheTest extends TestCase
         self::assertSame($generatedData, $data['test']);
 
         // Try again, now with a different callback
-        $result = $adapter->get('test', static fn () => [['POST' => ['/' => ['test', []]]], []]);
+        $result = $adapter->get('test', static fn () => [['POST' => ['/' => ['test', []]]], [], []]);
 
         self::assertSame($generatedData, $result);
     }

--- a/test/FastRouteTest.php
+++ b/test/FastRouteTest.php
@@ -16,9 +16,9 @@ final class FastRouteTest extends TestCase
     #[PHPUnit\Test]
     public function markShouldBeTheDefaultDispatcher(): void
     {
-        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...), 'test')
             ->disableCache()
-            ->dispatcher('test');
+            ->dispatcher();
 
         self::assertInstanceOf(Dispatcher\MarkBased::class, $dispatcher);
     }
@@ -26,10 +26,10 @@ final class FastRouteTest extends TestCase
     #[PHPUnit\Test]
     public function canBeConfiguredToUseCharCountDispatcher(): void
     {
-        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...), 'test')
             ->disableCache()
             ->useCharCountDispatcher()
-            ->dispatcher('test');
+            ->dispatcher();
 
         self::assertInstanceOf(Dispatcher\CharCountBased::class, $dispatcher);
     }
@@ -37,10 +37,10 @@ final class FastRouteTest extends TestCase
     #[PHPUnit\Test]
     public function canBeConfiguredToUseGroupPosDispatcher(): void
     {
-        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...), 'test')
             ->disableCache()
             ->useGroupPosDispatcher()
-            ->dispatcher('test');
+            ->dispatcher();
 
         self::assertInstanceOf(Dispatcher\GroupPosBased::class, $dispatcher);
     }
@@ -48,10 +48,10 @@ final class FastRouteTest extends TestCase
     #[PHPUnit\Test]
     public function canBeConfiguredToUseGroupCountDispatcher(): void
     {
-        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...), 'test')
             ->disableCache()
             ->useGroupCountDispatcher()
-            ->dispatcher('test');
+            ->dispatcher();
 
         self::assertInstanceOf(Dispatcher\GroupCountBased::class, $dispatcher);
     }
@@ -59,11 +59,11 @@ final class FastRouteTest extends TestCase
     #[PHPUnit\Test]
     public function canBeConfiguredToUseMarkDispatcher(): void
     {
-        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...), 'test')
             ->disableCache()
             ->useCharCountDispatcher()
             ->useMarkDispatcher()
-            ->dispatcher('test');
+            ->dispatcher();
 
         self::assertInstanceOf(Dispatcher\MarkBased::class, $dispatcher);
     }
@@ -76,16 +76,16 @@ final class FastRouteTest extends TestCase
             public function get(string $key, callable $loader): array
             {
                 if ($key === 'test') {
-                    return [['GET' => ['/' => ['test2', ['test' => true]]]], []];
+                    return [['GET' => ['/' => ['test2', ['test' => true]]]], [], []];
                 }
 
                 throw new RuntimeException('This dummy implementation is not meant for other cases');
             }
         };
 
-        $dispatcher = FastRoute::recommendedSettings(self::routes(...))
-            ->withCache($cache)
-            ->dispatcher('test');
+        $dispatcher = FastRoute::recommendedSettings(self::routes(...), 'test2')
+            ->withCache($cache, 'test')
+            ->dispatcher();
 
         $result = $dispatcher->dispatch('GET', '/');
 

--- a/test/FastRouteTest.php
+++ b/test/FastRouteTest.php
@@ -7,6 +7,7 @@ use FastRoute\Cache;
 use FastRoute\ConfigureRoutes;
 use FastRoute\Dispatcher;
 use FastRoute\FastRoute;
+use FastRoute\GenerateUri;
 use PHPUnit\Framework\Attributes as PHPUnit;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -97,5 +98,71 @@ final class FastRouteTest extends TestCase
     private static function routes(ConfigureRoutes $collector): void
     {
         $collector->get('/', 'test');
+    }
+
+    #[PHPUnit\Test]
+    public function defaultUriGeneratorMustBeProvided(): void
+    {
+        $uriGenerator = FastRoute::recommendedSettings(self::routes(...), 'test')
+            ->disableCache()
+            ->uriGenerator();
+
+        self::assertInstanceOf(GenerateUri\FromProcessedConfiguration::class, $uriGenerator);
+    }
+
+    #[PHPUnit\Test]
+    public function uriGeneratorCanBeOverridden(): void
+    {
+        $generator = new class () implements GenerateUri {
+            /** @inheritDoc */
+            public function forRoute(string $name, array $substitutions = []): string
+            {
+                return '';
+            }
+        };
+
+        $uriGenerator = FastRoute::recommendedSettings(self::routes(...), 'test')
+            ->disableCache()
+            ->withUriGenerator($generator::class)
+            ->uriGenerator();
+
+        self::assertInstanceOf($generator::class, $uriGenerator);
+    }
+
+    #[PHPUnit\Test]
+    public function processedDataShouldOnlyBeBuiltOnce(): void
+    {
+        $loader = static function (ConfigureRoutes $routes): void {
+            $routes->addRoute(
+                ['GET', 'POST'],
+                '/users/{name}',
+                'do-stuff',
+                [ConfigureRoutes::ROUTE_NAME => 'users'],
+            );
+
+            $routes->get('/posts/{id}', 'fetchPosts', [ConfigureRoutes::ROUTE_NAME => 'posts.fetch']);
+
+            $routes->get(
+                '/articles/{year}[/{month}[/{day}]]',
+                'fetchArticle',
+                [ConfigureRoutes::ROUTE_NAME => 'articles.fetch'],
+            );
+        };
+
+        $fastRoute = FastRoute::recommendedSettings($loader, 'test')
+            ->disableCache();
+
+        $dispatcher   = $fastRoute->dispatcher();
+        $uriGenerator = $fastRoute->uriGenerator();
+
+        self::assertInstanceOf(Dispatcher\Result\Matched::class, $dispatcher->dispatch('GET', '/users/lcobucci'));
+        self::assertInstanceOf(Dispatcher\Result\Matched::class, $dispatcher->dispatch('POST', '/users/lcobucci'));
+        self::assertInstanceOf(Dispatcher\Result\Matched::class, $dispatcher->dispatch('GET', '/posts/1234'));
+
+        self::assertSame('/users/lcobucci', $uriGenerator->forRoute('users', ['name' => 'lcobucci']));
+        self::assertSame('/posts/1234', $uriGenerator->forRoute('posts.fetch', ['id' => '1234']));
+        self::assertSame('/articles/2024', $uriGenerator->forRoute('articles.fetch', ['year' => '2024']));
+        self::assertSame('/articles/2024/02', $uriGenerator->forRoute('articles.fetch', ['year' => '2024', 'month' => '02']));
+        self::assertSame('/articles/2024/02/15', $uriGenerator->forRoute('articles.fetch', ['year' => '2024', 'month' => '02', 'day' => '15']));
     }
 }

--- a/test/GenerateUri/FromProcessedConfigurationTest.php
+++ b/test/GenerateUri/FromProcessedConfigurationTest.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute\Test\GenerateUri;
+
+use FastRoute\GenerateUri;
+use FastRoute\RouteParser;
+use PHPUnit\Framework\Attributes as PHPUnit;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function array_reverse;
+
+/** @phpstan-import-type ParsedRoutes from RouteParser */
+final class FromProcessedConfigurationTest extends TestCase
+{
+    #[PHPUnit\Test]
+    public function undefinedRoutesCannotHaveTheirUriGenerated(): void
+    {
+        $generator = self::routeGeneratorFor(['post.fetch' => '/post/{id:\d+}']);
+
+        $this->expectException(GenerateUri\UriCouldNotBeGenerated::class);
+        $this->expectExceptionMessage('There is no route with name "test" defined');
+
+        $generator->forRoute('test');
+    }
+
+    #[PHPUnit\Test]
+    public function itCannotGenerateUriWhenNoneOfTheRequiredParametersAreGiven(): void
+    {
+        $generator = self::routeGeneratorFor(['post.fetch' => '/post/{id:\d+}']);
+
+        $this->expectException(GenerateUri\UriCouldNotBeGenerated::class);
+        $this->expectExceptionMessage('Route "post.fetch" expects at least parameter values for [id], but received none');
+
+        $generator->forRoute('post.fetch');
+    }
+
+    #[PHPUnit\Test]
+    public function itCannotGenerateUriWhenIrrelevantParametersAreGiven(): void
+    {
+        $generator = self::routeGeneratorFor(['post.fetch' => '/post/{id:\d+}']);
+
+        $this->expectException(GenerateUri\UriCouldNotBeGenerated::class);
+        $this->expectExceptionMessage('Route "post.fetch" expects at least parameter values for [id], but received [name,age]');
+
+        $generator->forRoute('post.fetch', ['name' => 'me', 'age' => '1234']);
+    }
+
+    #[PHPUnit\Test]
+    public function argumentValidationMustBeRespected(): void
+    {
+        $generator = self::routeGeneratorFor(['post.fetch' => '/post/{id:\d+}']);
+
+        $this->expectException(GenerateUri\UriCouldNotBeGenerated::class);
+        $this->expectExceptionMessage('Route "post.fetch" expects the parameter [id] to match the regex `\d+`');
+
+        $generator->forRoute('post.fetch', ['id' => 'test']);
+    }
+
+    #[PHPUnit\Test]
+    public function routesWithOptionalSegmentsCanBeGenerated(): void
+    {
+        $generator = self::routeGeneratorFor(['archive.fetch' => '/archive/{username}[/{year}[/{month}[/{day}]]]']);
+
+        self::assertSame(
+            '/archive/test',
+            $generator->forRoute('archive.fetch', ['username' => 'test']),
+        );
+
+        self::assertSame(
+            '/archive/test/2024',
+            $generator->forRoute('archive.fetch', ['username' => 'test', 'year' => '2024']),
+        );
+
+        self::assertSame(
+            '/archive/test/2024/02',
+            $generator->forRoute('archive.fetch', ['username' => 'test', 'year' => '2024', 'month' => '02']),
+        );
+
+        self::assertSame(
+            '/archive/test/2024/02/01',
+            $generator->forRoute(
+                'archive.fetch',
+                ['username' => 'test', 'year' => '2024', 'month' => '02', 'day' => '01'],
+            ),
+        );
+    }
+
+    #[PHPUnit\Test]
+    public function staticRoutesCanAlsoBeGenerated(): void
+    {
+        $generator = self::routeGeneratorFor(['post.fetch-special' => '/post/a-special-post']);
+
+        self::assertSame('/post/a-special-post', $generator->forRoute('post.fetch-special'));
+    }
+
+    #[PHPUnit\Test]
+    public function resultingUriMustNotHaveUrlEncodedParameters(): void
+    {
+        $generator = self::routeGeneratorFor(['post.fetch' => '/post/{id}']);
+
+        self::assertSame(
+            '/post/@something-that needs to be encoded 😁',
+            $generator->forRoute('post.fetch', ['id' => '@something-that needs to be encoded 😁']),
+        );
+    }
+
+    #[PHPUnit\Test]
+    public function urlEncodedParametersShouldNotBeManipulated(): void
+    {
+        $generator = self::routeGeneratorFor(['post.fetch' => '/post/{id}']);
+
+        self::assertSame(
+            '/post/%40something%20that%20needs%20to%20be%20encoded%20%F0%9F%98%81',
+            $generator->forRoute('post.fetch', ['id' => '%40something%20that%20needs%20to%20be%20encoded%20%F0%9F%98%81']),
+        );
+    }
+
+    #[PHPUnit\Test]
+    public function unicodeParametersAreAlsoAccepted(): void
+    {
+        $generator = self::routeGeneratorFor(['post.fetch' => '/post/{id:[\w\-\%]+}']);
+
+        self::assertSame('/post/bar-測試', $generator->forRoute('post.fetch', ['id' => 'bar-測試']));
+    }
+
+    /** @param non-empty-array<non-empty-string, non-empty-string> $routeMap */
+    private static function routeGeneratorFor(array $routeMap): GenerateUri
+    {
+        $parseRoutes = static function (string $route): array {
+            return array_reverse((new RouteParser\Std())->parse($route));
+        };
+
+        return new GenerateUri\FromProcessedConfiguration(array_map($parseRoutes, $routeMap));
+    }
+}


### PR DESCRIPTION
Fixes #139 
Fixes #66 

This is an alternative implementation for #270, leveraging extra parameters for configuring things instead of following conventions around the handler.

The route generation process is a copy of https://github.com/mezzio/mezzio-fastroute/blob/3.12.x/src/FastRouteRouter.php#L248 (created by @weierophinney) with minor changes.

I still need to:

- [x] Add more tests
- [x] Provide better exceptions
- [x] Add benchmarks
- [x] Verify whether or not it makes sense to provide that functionality for static routes

The main arguments for following this approach are:

1. Not mixing handlers and route names, allowing people to also generate URIs when using callables
2. Providing validations for the substitution arguments
3. Trading data generation performance for URI generation performance