### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
         with:
           fetch-depth: 0
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,12 +17,14 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
         operating-system:
           - "ubuntu-latest"
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -33,7 +35,7 @@ jobs:
           tools: composer:v2, cs2pr
 
       - name: "Install dependencies"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -32,7 +32,7 @@ jobs:
           tools: composer:v2, cs2pr
 
       - name: "Install dependencies"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 

--- a/.github/workflows/composer-json-lint.yml
+++ b/.github/workflows/composer-json-lint.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -32,7 +32,7 @@ jobs:
           tools: composer:v2, composer-normalize, composer-require-checker, composer-unused
 
       - name: "Install dependencies"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -52,7 +52,7 @@ jobs:
         run: "composer config --no-interaction -- minimum-stability dev"
 
       - name: "Install dependencies"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -32,7 +32,7 @@ jobs:
           tools: composer:v2, cs2pr
 
       - name: "Install dependencies"
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /vendor/
 .idea/
 
+phpcs.xml
+phpstan.neon
 phpunit.xml
 /*.cache
 /.phpbench


### PR DESCRIPTION
Hey,

this PR updates the workflow runs to use the latest versions of `actions/checkout` and `ramsey/composer-install` to stop the node.js deprecation warnings.

Further I have moved the PHPUnit cache directory under `.build/.phpunit.cache` (now looking at it, the leading `.` is a bit unnecessary) and cleaned up the `.gitignore`.


Cheers!