### PR TITLE
Make ConfigureRoutes fluent

### DIFF
--- a/src/ConfigureRoutes.php
+++ b/src/ConfigureRoutes.php
@@ -23,14 +23,14 @@ interface ConfigureRoutes
      * @param string|string[] $httpMethod
      * @param ExtraParameters $extraParameters
      */
-    public function addRoute(string|array $httpMethod, string $route, mixed $handler, array $extraParameters = []): void;
+    public function addRoute(string|array $httpMethod, string $route, mixed $handler, array $extraParameters = []): static;
 
     /**
      * Create a route group with a common prefix.
      *
      * All routes created by the passed callback will have the given group prefix prepended.
      */
-    public function addGroup(string $prefix, callable $callback): void;
+    public function addGroup(string $prefix, callable $callback): static;
 
     /**
      * Adds a fallback route to the collection
@@ -39,7 +39,7 @@ interface ConfigureRoutes
      *
      * @param ExtraParameters $extraParameters
      */
-    public function any(string $route, mixed $handler, array $extraParameters = []): void;
+    public function any(string $route, mixed $handler, array $extraParameters = []): static;
 
     /**
      * Adds a GET route to the collection
@@ -48,7 +48,7 @@ interface ConfigureRoutes
      *
      * @param ExtraParameters $extraParameters
      */
-    public function get(string $route, mixed $handler, array $extraParameters = []): void;
+    public function get(string $route, mixed $handler, array $extraParameters = []): static;
 
     /**
      * Adds a POST route to the collection
@@ -57,7 +57,7 @@ interface ConfigureRoutes
      *
      * @param ExtraParameters $extraParameters
      */
-    public function post(string $route, mixed $handler, array $extraParameters = []): void;
+    public function post(string $route, mixed $handler, array $extraParameters = []): static;
 
     /**
      * Adds a PUT route to the collection
@@ -66,7 +66,7 @@ interface ConfigureRoutes
      *
      * @param ExtraParameters $extraParameters
      */
-    public function put(string $route, mixed $handler, array $extraParameters = []): void;
+    public function put(string $route, mixed $handler, array $extraParameters = []): static;
 
     /**
      * Adds a DELETE route to the collection
@@ -75,7 +75,7 @@ interface ConfigureRoutes
      *
      * @param ExtraParameters $extraParameters
      */
-    public function delete(string $route, mixed $handler, array $extraParameters = []): void;
+    public function delete(string $route, mixed $handler, array $extraParameters = []): static;
 
     /**
      * Adds a PATCH route to the collection
@@ -84,7 +84,7 @@ interface ConfigureRoutes
      *
      * @param ExtraParameters $extraParameters
      */
-    public function patch(string $route, mixed $handler, array $extraParameters = []): void;
+    public function patch(string $route, mixed $handler, array $extraParameters = []): static;
 
     /**
      * Adds a HEAD route to the collection
@@ -93,7 +93,7 @@ interface ConfigureRoutes
      *
      * @param ExtraParameters $extraParameters
      */
-    public function head(string $route, mixed $handler, array $extraParameters = []): void;
+    public function head(string $route, mixed $handler, array $extraParameters = []): static;
 
     /**
      * Adds an OPTIONS route to the collection
@@ -102,7 +102,7 @@ interface ConfigureRoutes
      *
      * @param ExtraParameters $extraParameters
      */
-    public function options(string $route, mixed $handler, array $extraParameters = []): void;
+    public function options(string $route, mixed $handler, array $extraParameters = []): static;
 
     /**
      * Returns the processed aggregated route data.

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -28,7 +28,7 @@ class RouteCollector implements ConfigureRoutes
     }
 
     /** @inheritDoc */
-    public function addRoute(string|array $httpMethod, string $route, mixed $handler, array $extraParameters = []): void
+    public function addRoute(string|array $httpMethod, string $route, mixed $handler, array $extraParameters = []): static
     {
         $route = $this->currentGroupPrefix . $route;
         $parsedRoutes = $this->routeParser->parse($route);
@@ -44,6 +44,8 @@ class RouteCollector implements ConfigureRoutes
         if (array_key_exists(self::ROUTE_NAME, $extraParameters)) {
             $this->registerNamedRoute($extraParameters[self::ROUTE_NAME], $parsedRoutes);
         }
+
+        return $this;
     }
 
     /** @param ParsedRoutes $parsedRoutes */
@@ -60,60 +62,62 @@ class RouteCollector implements ConfigureRoutes
         $this->namedRoutes[$name] = array_reverse($parsedRoutes);
     }
 
-    public function addGroup(string $prefix, callable $callback): void
+    public function addGroup(string $prefix, callable $callback): static
     {
         $previousGroupPrefix = $this->currentGroupPrefix;
         $this->currentGroupPrefix = $previousGroupPrefix . $prefix;
         $callback($this);
         $this->currentGroupPrefix = $previousGroupPrefix;
+
+        return $this;
     }
 
     /** @inheritDoc */
-    public function any(string $route, mixed $handler, array $extraParameters = []): void
+    public function any(string $route, mixed $handler, array $extraParameters = []): static
     {
-        $this->addRoute('*', $route, $handler, $extraParameters);
+        return $this->addRoute('*', $route, $handler, $extraParameters);
     }
 
     /** @inheritDoc */
-    public function get(string $route, mixed $handler, array $extraParameters = []): void
+    public function get(string $route, mixed $handler, array $extraParameters = []): static
     {
-        $this->addRoute('GET', $route, $handler, $extraParameters);
+        return $this->addRoute('GET', $route, $handler, $extraParameters);
     }
 
     /** @inheritDoc */
-    public function post(string $route, mixed $handler, array $extraParameters = []): void
+    public function post(string $route, mixed $handler, array $extraParameters = []): static
     {
-        $this->addRoute('POST', $route, $handler, $extraParameters);
+        return $this->addRoute('POST', $route, $handler, $extraParameters);
     }
 
     /** @inheritDoc */
-    public function put(string $route, mixed $handler, array $extraParameters = []): void
+    public function put(string $route, mixed $handler, array $extraParameters = []): static
     {
-        $this->addRoute('PUT', $route, $handler, $extraParameters);
+        return $this->addRoute('PUT', $route, $handler, $extraParameters);
     }
 
     /** @inheritDoc */
-    public function delete(string $route, mixed $handler, array $extraParameters = []): void
+    public function delete(string $route, mixed $handler, array $extraParameters = []): static
     {
-        $this->addRoute('DELETE', $route, $handler, $extraParameters);
+        return $this->addRoute('DELETE', $route, $handler, $extraParameters);
     }
 
     /** @inheritDoc */
-    public function patch(string $route, mixed $handler, array $extraParameters = []): void
+    public function patch(string $route, mixed $handler, array $extraParameters = []): static
     {
-        $this->addRoute('PATCH', $route, $handler, $extraParameters);
+        return $this->addRoute('PATCH', $route, $handler, $extraParameters);
     }
 
     /** @inheritDoc */
-    public function head(string $route, mixed $handler, array $extraParameters = []): void
+    public function head(string $route, mixed $handler, array $extraParameters = []): static
     {
-        $this->addRoute('HEAD', $route, $handler, $extraParameters);
+        return $this->addRoute('HEAD', $route, $handler, $extraParameters);
     }
 
     /** @inheritDoc */
-    public function options(string $route, mixed $handler, array $extraParameters = []): void
+    public function options(string $route, mixed $handler, array $extraParameters = []): static
     {
-        $this->addRoute('OPTIONS', $route, $handler, $extraParameters);
+        return $this->addRoute('OPTIONS', $route, $handler, $extraParameters);
     }
 
     /** @inheritDoc */

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -4,29 +4,9 @@ declare(strict_types=1);
 namespace FastRoute;
 
 use function array_key_exists;
-use function array_reverse;
-use function is_string;
 
-/**
- * @phpstan-import-type ProcessedData from ConfigureRoutes
- * @phpstan-import-type ExtraParameters from DataGenerator
- * @phpstan-import-type RoutesForUriGeneration from GenerateUri
- * @phpstan-import-type ParsedRoutes from RouteParser
- * @final
- */
-class RouteCollector implements ConfigureRoutes
+final class RouteCollector extends RouteCollectorAbstract
 {
-    protected string $currentGroupPrefix = '';
-
-    /** @var RoutesForUriGeneration */
-    private array $namedRoutes = [];
-
-    public function __construct(
-        protected readonly RouteParser $routeParser,
-        protected readonly DataGenerator $dataGenerator,
-    ) {
-    }
-
     /** @inheritDoc */
     public function addRoute(string|array $httpMethod, string $route, mixed $handler, array $extraParameters = []): static
     {
@@ -48,20 +28,7 @@ class RouteCollector implements ConfigureRoutes
         return $this;
     }
 
-    /** @param ParsedRoutes $parsedRoutes */
-    private function registerNamedRoute(mixed $name, array $parsedRoutes): void
-    {
-        if (! is_string($name) || $name === '') {
-            throw BadRouteException::invalidRouteName($name);
-        }
-
-        if (array_key_exists($name, $this->namedRoutes)) {
-            throw BadRouteException::namedRouteAlreadyDefined($name);
-        }
-
-        $this->namedRoutes[$name] = array_reverse($parsedRoutes);
-    }
-
+    /** @inheritDoc */
     public function addGroup(string $prefix, callable $callback): static
     {
         $previousGroupPrefix = $this->currentGroupPrefix;
@@ -70,74 +37,5 @@ class RouteCollector implements ConfigureRoutes
         $this->currentGroupPrefix = $previousGroupPrefix;
 
         return $this;
-    }
-
-    /** @inheritDoc */
-    public function any(string $route, mixed $handler, array $extraParameters = []): static
-    {
-        return $this->addRoute('*', $route, $handler, $extraParameters);
-    }
-
-    /** @inheritDoc */
-    public function get(string $route, mixed $handler, array $extraParameters = []): static
-    {
-        return $this->addRoute('GET', $route, $handler, $extraParameters);
-    }
-
-    /** @inheritDoc */
-    public function post(string $route, mixed $handler, array $extraParameters = []): static
-    {
-        return $this->addRoute('POST', $route, $handler, $extraParameters);
-    }
-
-    /** @inheritDoc */
-    public function put(string $route, mixed $handler, array $extraParameters = []): static
-    {
-        return $this->addRoute('PUT', $route, $handler, $extraParameters);
-    }
-
-    /** @inheritDoc */
-    public function delete(string $route, mixed $handler, array $extraParameters = []): static
-    {
-        return $this->addRoute('DELETE', $route, $handler, $extraParameters);
-    }
-
-    /** @inheritDoc */
-    public function patch(string $route, mixed $handler, array $extraParameters = []): static
-    {
-        return $this->addRoute('PATCH', $route, $handler, $extraParameters);
-    }
-
-    /** @inheritDoc */
-    public function head(string $route, mixed $handler, array $extraParameters = []): static
-    {
-        return $this->addRoute('HEAD', $route, $handler, $extraParameters);
-    }
-
-    /** @inheritDoc */
-    public function options(string $route, mixed $handler, array $extraParameters = []): static
-    {
-        return $this->addRoute('OPTIONS', $route, $handler, $extraParameters);
-    }
-
-    /** @inheritDoc */
-    public function processedRoutes(): array
-    {
-        $data =  $this->dataGenerator->getData();
-        $data[] = $this->namedRoutes;
-
-        return $data;
-    }
-
-    /**
-     * @deprecated
-     *
-     * @see ConfigureRoutes::processedRoutes()
-     *
-     * @return ProcessedData
-     */
-    public function getData(): array
-    {
-        return $this->processedRoutes();
     }
 }

--- a/src/RouteCollectorAbstract.php
+++ b/src/RouteCollectorAbstract.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute;
+
+use function array_key_exists;
+use function array_reverse;
+use function is_string;
+
+/**
+ * @phpstan-import-type ProcessedData from ConfigureRoutes
+ * @phpstan-import-type ExtraParameters from DataGenerator
+ * @phpstan-import-type RoutesForUriGeneration from GenerateUri
+ * @phpstan-import-type ParsedRoutes from RouteParser
+ */
+abstract class RouteCollectorAbstract implements ConfigureRoutes
+{
+    protected string $currentGroupPrefix = '';
+
+    /** @var RoutesForUriGeneration */
+    protected array $namedRoutes = [];
+
+    public function __construct(
+        protected readonly RouteParser $routeParser,
+        protected DataGenerator $dataGenerator,
+    ) {
+    }
+
+    /** @param ParsedRoutes $parsedRoutes */
+    protected function registerNamedRoute(mixed $name, array $parsedRoutes): void
+    {
+        if (! is_string($name) || $name === '') {
+            throw BadRouteException::invalidRouteName($name);
+        }
+
+        if (array_key_exists($name, $this->namedRoutes)) {
+            throw BadRouteException::namedRouteAlreadyDefined($name);
+        }
+
+        $this->namedRoutes[$name] = array_reverse($parsedRoutes);
+    }
+
+    /** @inheritDoc */
+    public function processedRoutes(): array
+    {
+        $data =  $this->dataGenerator->getData();
+        $data[] = $this->namedRoutes;
+
+        return $data;
+    }
+
+    /**
+     * @deprecated
+     *
+     * @see ConfigureRoutes::processedRoutes()
+     *
+     * @return ProcessedData
+     */
+    public function getData(): array
+    {
+        return $this->processedRoutes();
+    }
+
+    /** @inheritDoc */
+    public function any(string $route, mixed $handler, array $extraParameters = []): static
+    {
+        return $this->addRoute('*', $route, $handler, $extraParameters);
+    }
+
+    /** @inheritDoc */
+    public function get(string $route, mixed $handler, array $extraParameters = []): static
+    {
+        return $this->addRoute('GET', $route, $handler, $extraParameters);
+    }
+
+    /** @inheritDoc */
+    public function post(string $route, mixed $handler, array $extraParameters = []): static
+    {
+        return $this->addRoute('POST', $route, $handler, $extraParameters);
+    }
+
+    /** @inheritDoc */
+    public function put(string $route, mixed $handler, array $extraParameters = []): static
+    {
+        return $this->addRoute('PUT', $route, $handler, $extraParameters);
+    }
+
+    /** @inheritDoc */
+    public function delete(string $route, mixed $handler, array $extraParameters = []): static
+    {
+        return $this->addRoute('DELETE', $route, $handler, $extraParameters);
+    }
+
+    /** @inheritDoc */
+    public function patch(string $route, mixed $handler, array $extraParameters = []): static
+    {
+        return $this->addRoute('PATCH', $route, $handler, $extraParameters);
+    }
+
+    /** @inheritDoc */
+    public function head(string $route, mixed $handler, array $extraParameters = []): static
+    {
+        return $this->addRoute('HEAD', $route, $handler, $extraParameters);
+    }
+
+    /** @inheritDoc */
+    public function options(string $route, mixed $handler, array $extraParameters = []): static
+    {
+        return $this->addRoute('OPTIONS', $route, $handler, $extraParameters);
+    }
+}

--- a/src/RouteCollectorImmutable.php
+++ b/src/RouteCollectorImmutable.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute;
+
+use function array_key_exists;
+
+final class RouteCollectorImmutable extends RouteCollectorAbstract
+{
+    /** @inheritDoc */
+    public function addRoute(string|array $httpMethod, string $route, mixed $handler, array $extraParameters = []): static
+    {
+        $clone = clone $this;
+        $clone->dataGenerator = clone $clone->dataGenerator;
+
+        $route = $clone->currentGroupPrefix . $route;
+        $parsedRoutes = $clone->routeParser->parse($route);
+
+        $extraParameters = [self::ROUTE_REGEX => $route] + $extraParameters;
+
+        foreach ((array) $httpMethod as $method) {
+            foreach ($parsedRoutes as $parsedRoute) {
+                $clone->dataGenerator->addRoute($method, $parsedRoute, $handler, $extraParameters);
+            }
+        }
+
+        if (array_key_exists(self::ROUTE_NAME, $extraParameters)) {
+            $clone->registerNamedRoute($extraParameters[self::ROUTE_NAME], $parsedRoutes);
+        }
+
+        return $clone;
+    }
+
+    /** @inheritDoc */
+    public function addGroup(string $prefix, callable $callback): static
+    {
+        $clone = clone $this;
+
+        $previousGroupPrefix = $clone->currentGroupPrefix;
+        $clone->currentGroupPrefix = $previousGroupPrefix . $prefix;
+        $clone = $callback($clone);
+        $clone->currentGroupPrefix = $previousGroupPrefix;
+
+        return $clone;
+    }
+}

--- a/test/RouteCollectorImmutableTest.php
+++ b/test/RouteCollectorImmutableTest.php
@@ -1,0 +1,190 @@
+<?php
+declare(strict_types=1);
+
+namespace FastRoute\Test;
+
+use FastRoute\BadRouteException;
+use FastRoute\ConfigureRoutes;
+use FastRoute\DataGenerator;
+use FastRoute\RouteCollectorImmutable;
+use FastRoute\RouteParser\Std;
+use PHPUnit\Framework\Attributes as PHPUnit;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+use function is_string;
+
+final class RouteCollectorImmutableTest extends TestCase
+{
+    #[PHPUnit\Test]
+    public function shortcutsCanBeUsedToRegisterRoutes(): void
+    {
+        $r = self::routeCollector();
+
+        $immutable = $r
+            ->any('/any', 'any')
+            ->delete('/delete', 'delete')
+            ->get('/get', 'get')
+            ->head('/head', 'head')
+            ->patch('/patch', 'patch')
+            ->post('/post', 'post')
+            ->put('/put', 'put')
+            ->options('/options', 'options');
+
+        $expected = [
+            ['*', '/any', 'any', ['_route' => '/any']],
+            ['DELETE', '/delete', 'delete', ['_route' => '/delete']],
+            ['GET', '/get', 'get', ['_route' => '/get']],
+            ['HEAD', '/head', 'head', ['_route' => '/head']],
+            ['PATCH', '/patch', 'patch', ['_route' => '/patch']],
+            ['POST', '/post', 'post', ['_route' => '/post']],
+            ['PUT', '/put', 'put', ['_route' => '/put']],
+            ['OPTIONS', '/options', 'options', ['_route' => '/options']],
+        ];
+
+        self::assertSame($expected, $immutable->processedRoutes()[0]);
+    }
+
+    #[PHPUnit\Test]
+    public function routesCanBeGrouped(): void
+    {
+        $r = self::routeCollector();
+
+        $immutable = $r
+            ->delete('/delete', 'delete')
+            ->get('/get', 'get')
+            ->head('/head', 'head')
+            ->patch('/patch', 'patch')
+            ->post('/post', 'post')
+            ->put('/put', 'put')
+            ->options('/options', 'options');
+
+        $immutable = $immutable->addGroup('/group-one', static function (ConfigureRoutes $r1): ConfigureRoutes {
+            $immutable1 = $r1
+                ->delete('/delete', 'delete')
+                ->get('/get', 'get')
+                ->head('/head', 'head')
+                ->patch('/patch', 'patch')
+                ->post('/post', 'post')
+                ->put('/put', 'put')
+                ->options('/options', 'options');
+
+            return $immutable1->addGroup('/group-two', static function (ConfigureRoutes $r2): ConfigureRoutes {
+                return $r2
+                    ->delete('/delete', 'delete')
+                    ->get('/get', 'get')
+                    ->head('/head', 'head')
+                    ->patch('/patch', 'patch')
+                    ->post('/post', 'post')
+                    ->put('/put', 'put')
+                    ->options('/options', 'options');
+            });
+        });
+
+        $immutable = $immutable->addGroup('/admin', static function (ConfigureRoutes $r): ConfigureRoutes {
+            return $r->get('-some-info', 'admin-some-info');
+        });
+
+        $immutable = $immutable->addGroup('/admin-', static function (ConfigureRoutes $r): ConfigureRoutes {
+            return $r->get('more-info', 'admin-more-info');
+        });
+
+        $expected = [
+            ['DELETE', '/delete', 'delete', ['_route' => '/delete']],
+            ['GET', '/get', 'get', ['_route' => '/get']],
+            ['HEAD', '/head', 'head', ['_route' => '/head']],
+            ['PATCH', '/patch', 'patch', ['_route' => '/patch']],
+            ['POST', '/post', 'post', ['_route' => '/post']],
+            ['PUT', '/put', 'put', ['_route' => '/put']],
+            ['OPTIONS', '/options', 'options', ['_route' => '/options']],
+            ['DELETE', '/group-one/delete', 'delete', ['_route' => '/group-one/delete']],
+            ['GET', '/group-one/get', 'get', ['_route' => '/group-one/get']],
+            ['HEAD', '/group-one/head', 'head', ['_route' => '/group-one/head']],
+            ['PATCH', '/group-one/patch', 'patch', ['_route' => '/group-one/patch']],
+            ['POST', '/group-one/post', 'post', ['_route' => '/group-one/post']],
+            ['PUT', '/group-one/put', 'put', ['_route' => '/group-one/put']],
+            ['OPTIONS', '/group-one/options', 'options', ['_route' => '/group-one/options']],
+            ['DELETE', '/group-one/group-two/delete', 'delete', ['_route' => '/group-one/group-two/delete']],
+            ['GET', '/group-one/group-two/get', 'get', ['_route' => '/group-one/group-two/get']],
+            ['HEAD', '/group-one/group-two/head', 'head', ['_route' => '/group-one/group-two/head']],
+            ['PATCH', '/group-one/group-two/patch', 'patch', ['_route' => '/group-one/group-two/patch']],
+            ['POST', '/group-one/group-two/post', 'post', ['_route' => '/group-one/group-two/post']],
+            ['PUT', '/group-one/group-two/put', 'put', ['_route' => '/group-one/group-two/put']],
+            ['OPTIONS', '/group-one/group-two/options', 'options', ['_route' => '/group-one/group-two/options']],
+            ['GET', '/admin-some-info', 'admin-some-info', ['_route' => '/admin-some-info']],
+            ['GET', '/admin-more-info', 'admin-more-info', ['_route' => '/admin-more-info']],
+        ];
+
+        self::assertSame($expected, $immutable->processedRoutes()[0]);
+    }
+
+    #[PHPUnit\Test]
+    public function namedRoutesShouldBeRegistered(): void
+    {
+        $r = self::routeCollector();
+
+        $immutable = $r->get('/', 'index-handler', ['_name' => 'index']);
+        $immutable = $immutable->get('/users/me', 'fetch-user-handler', ['_name' => 'users.fetch']);
+
+        self::assertSame(['index' => [['/']], 'users.fetch' => [['/users/me']]], $immutable->processedRoutes()[2]);
+    }
+
+    #[PHPUnit\Test]
+    public function cannotDefineRouteWithEmptyName(): void
+    {
+        $r = self::routeCollector();
+
+        $this->expectException(BadRouteException::class);
+
+        $r->get('/', 'index-handler', ['_name' => '']);
+    }
+
+    #[PHPUnit\Test]
+    public function cannotDefineRouteWithInvalidTypeAsName(): void
+    {
+        $r = self::routeCollector();
+
+        $this->expectException(BadRouteException::class);
+
+        $r->get('/', 'index-handler', ['_name' => false]);
+    }
+
+    #[PHPUnit\Test]
+    public function cannotDefineDuplicatedRouteName(): void
+    {
+        $r = self::routeCollector();
+
+        $this->expectException(BadRouteException::class);
+
+        $immutable = $r->get('/', 'index-handler', ['_name' => 'index']);
+        $immutable->get('/users/me', 'fetch-user-handler', ['_name' => 'index']);
+    }
+
+    private static function routeCollector(): ConfigureRoutes
+    {
+        return new RouteCollectorImmutable(new Std(), self::dummyDataGenerator());
+    }
+
+    private static function dummyDataGenerator(): DataGenerator
+    {
+        return new class implements DataGenerator
+        {
+            /** @var list<array{string, string, mixed, array<string, bool|float|int|string>}> */
+            private array $routes = [];
+
+            /** @inheritDoc */
+            public function getData(): array
+            {
+                return [$this->routes, []];
+            }
+
+            /** @inheritDoc */
+            public function addRoute(string $httpMethod, array $routeData, mixed $handler, array $extraParameters = []): void
+            {
+                TestCase::assertTrue(count($routeData) === 1 && is_string($routeData[0]));
+
+                $this->routes[] = [$httpMethod, $routeData[0], $handler, $extraParameters];
+            }
+        };
+    }
+}


### PR DESCRIPTION
Ok, I'm trying [this again](https://github.com/nikic/FastRoute/pull/181) :)

Now that we have the `static` return type, we can write pretty fluent interfaces without worrying about messy return types, yay!
And while this may be opinionated, it clearly adds value as it allows to write cleaner code:

```php
$dispatcher = FastRoute\simpleDispatcher(function(FastRoute\ConfigureRoutes $routeCollector) {

    $routeCollector->get('/users', 'get_all_users_handler');
    $routeCollector->get('/user/{id:\d+}', 'get_user_handler');
    $routeCollector->get('/articles/{id:\d+}[/{title}]', 'get_article_handler');

    // ...
});
```

vs.

```php
$dispatcher = FastRoute\simpleDispatcher(function(FastRoute\ConfigureRoutes $routeCollector) {

    $routeCollector
        ->get('/users', 'get_all_users_handler')
        ->get('/user/{id:\d+}', 'get_user_handler')
        ->get('/articles/{id:\d+}[/{title}]', 'get_article_handler')
    ;

    // ...
});
```